### PR TITLE
fix(cf-worker): bump tar/js-yaml/brace-expansion/fast-uri to clear CVEs

### DIFF
--- a/backend/cf-worker/package-lock.json
+++ b/backend/cf-worker/package-lock.json
@@ -1548,9 +1548,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1917,9 +1917,9 @@
       "optional": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -3422,9 +3422,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "optional": true,

--- a/backend/cf-worker/package.json
+++ b/backend/cf-worker/package.json
@@ -20,7 +20,9 @@
   "overrides": {
     "ws": "^8.20.1",
     "undici": "^7.28.0",
-    "tar": "^7.5.16",
-    "js-yaml": "^4.2.0"
+    "tar": "^7.5.19",
+    "js-yaml": "^4.3.0",
+    "brace-expansion": "^2.1.2",
+    "fast-uri": "^3.1.3"
   }
 }


### PR DESCRIPTION
## Summary
Main went red after PRs #4/#5 merged: the fresh OSV scan surfaced 7 newly-disclosed npm CVEs in `backend/cf-worker/package-lock.json` (all **dev** deps of the wrangler/esbuild toolchain), including a **critical** tar advisory (GHSA-23hp-3jrh-7fpw, CVSS 9.2). The action bumps were innocent; they just triggered the re-scan.

Bumps the `overrides` in `backend/cf-worker/package.json` to the fixed versions and regenerates the lockfile:

| Package | Old | New | Worst |
|---|---|---|---|
| tar | 7.5.16 | 7.5.20 | 9.2 Critical |
| brace-expansion | 2.1.0 | 2.1.2 | 7.7 |
| fast-uri | 3.1.2 | 3.1.4 | 7.5 |
| js-yaml | 4.2.0 | 4.3.0 | 7.5 |

`npm audit` now reports **0 vulnerabilities**.

## Telemetry note
Touches the Cloudflare telemetry worker's dependency lockfile only (dev/build deps). No runtime, payload, or consent-model change.

## Test plan
- [x] `npm install --package-lock-only` → 0 vulnerabilities
- [ ] CI OSV scan passes green