### PR TITLE
test(qml): stop the headless suite calling GitHub and crashing pytest

### DIFF
--- a/tests/test_qml_compact_view.py
+++ b/tests/test_qml_compact_view.py
@@ -93,6 +93,19 @@ def qml_root(qapp):
     # subsequent runs. Clear the test-scoped store before each load.
     QSettings(TEST_ORG, TEST_APP).clear()
 
+    # Disarm the startup update check.  `savedAutoCheckUpdates` defaults to
+    # true, so three seconds after load Main.qml fires a real HTTPS request
+    # to the GitHub releases API from a daemon thread — in every headless QML
+    # test that lives that long.  Besides making the suite depend on the
+    # network, that thread emits its result back into a bridge the fixture
+    # has already torn down, which surfaces as `RuntimeError: Signal source
+    # has been deleted` or, in a longer run, a hard access violation that
+    # kills the whole pytest process.  Writing the setting before the load
+    # means `Component.onCompleted` never starts the timer at all.
+    settings = QSettings(TEST_ORG, TEST_APP)
+    settings.setValue("ui/savedAutoCheckUpdates", False)
+    settings.sync()
+
     with patch("src.keyboard_bridge.create_key_synthesizer") as factory:
         synth = MagicMock()
         synth.is_available.return_value = True

--- a/tests/test_qml_compact_view.py
+++ b/tests/test_qml_compact_view.py
@@ -95,7 +95,7 @@ def qml_root(qapp):
 
     # Disarm the startup update check.  `savedAutoCheckUpdates` defaults to
     # true, so three seconds after load Main.qml fires a real HTTPS request
-    # to the GitHub releases API from a daemon thread — in every headless QML
+    # to the GitHub releases API from a daemon thread, in every headless QML
     # test that lives that long.  Besides making the suite depend on the
     # network, that thread emits its result back into a bridge the fixture
     # has already torn down, which surfaces as `RuntimeError: Signal source

--- a/tests/test_qml_prediction_bar.py
+++ b/tests/test_qml_prediction_bar.py
@@ -137,7 +137,7 @@ def qml_root(qapp):
 
     # Disarm the startup update check.  `savedAutoCheckUpdates` defaults to
     # true, so three seconds after load Main.qml fires a real HTTPS request
-    # to the GitHub releases API from a daemon thread — in every headless QML
+    # to the GitHub releases API from a daemon thread, in every headless QML
     # test that lives that long.  Besides making the suite depend on the
     # network, that thread emits its result back into a bridge the fixture
     # has already torn down, which surfaces as `RuntimeError: Signal source

--- a/tests/test_qml_prediction_bar.py
+++ b/tests/test_qml_prediction_bar.py
@@ -135,6 +135,19 @@ def qml_root(qapp):
     warnings: list[str] = []
     QSettings(TEST_ORG, TEST_APP).clear()
 
+    # Disarm the startup update check.  `savedAutoCheckUpdates` defaults to
+    # true, so three seconds after load Main.qml fires a real HTTPS request
+    # to the GitHub releases API from a daemon thread — in every headless QML
+    # test that lives that long.  Besides making the suite depend on the
+    # network, that thread emits its result back into a bridge the fixture
+    # has already torn down, which surfaces as `RuntimeError: Signal source
+    # has been deleted` or, in a longer run, a hard access violation that
+    # kills the whole pytest process.  Writing the setting before the load
+    # means `Component.onCompleted` never starts the timer at all.
+    settings = QSettings(TEST_ORG, TEST_APP)
+    settings.setValue("ui/savedAutoCheckUpdates", False)
+    settings.sync()
+
     with patch("src.keyboard_bridge.create_key_synthesizer") as factory:
         synth = MagicMock()
         synth.is_available.return_value = True

--- a/tests/test_qml_swipe_overlay.py
+++ b/tests/test_qml_swipe_overlay.py
@@ -101,7 +101,7 @@ def swipe_root(qapp):
 
     # Disarm the startup update check.  `savedAutoCheckUpdates` defaults to
     # true, so three seconds after load Main.qml fires a real HTTPS request
-    # to the GitHub releases API from a daemon thread — in every headless QML
+    # to the GitHub releases API from a daemon thread, in every headless QML
     # test that lives that long.  Besides making the suite depend on the
     # network, that thread emits its result back into a bridge the fixture
     # has already torn down, which surfaces as `RuntimeError: Signal source

--- a/tests/test_qml_swipe_overlay.py
+++ b/tests/test_qml_swipe_overlay.py
@@ -99,6 +99,19 @@ def swipe_root(qapp):
     warnings: list[str] = []
     QSettings(TEST_ORG, TEST_APP).clear()
 
+    # Disarm the startup update check.  `savedAutoCheckUpdates` defaults to
+    # true, so three seconds after load Main.qml fires a real HTTPS request
+    # to the GitHub releases API from a daemon thread — in every headless QML
+    # test that lives that long.  Besides making the suite depend on the
+    # network, that thread emits its result back into a bridge the fixture
+    # has already torn down, which surfaces as `RuntimeError: Signal source
+    # has been deleted` or, in a longer run, a hard access violation that
+    # kills the whole pytest process.  Writing the setting before the load
+    # means `Component.onCompleted` never starts the timer at all.
+    settings = QSettings(TEST_ORG, TEST_APP)
+    settings.setValue("ui/savedAutoCheckUpdates", False)
+    settings.sync()
+
     with patch("src.keyboard_bridge.create_key_synthesizer") as factory:
         synth = MagicMock()
         synth.is_available.return_value = True


### PR DESCRIPTION
## Summary

Found while fuzzing the panel/compact branch (#22): the headless QML test suite makes real network calls, and the thread that makes them can take the whole pytest process down with an access violation.

`savedAutoCheckUpdates` defaults to true, so three seconds after loading `Main.qml` every headless QML test starts a live HTTPS request to the GitHub releases API on a daemon thread. That thread then emits its result back into a `KeyboardBridge` the fixture has already torn down.

It surfaces two ways:

- `RuntimeError: Signal source has been deleted` in the worker thread (visible today if you run a QML module standalone), and
- a hard **access violation that kills the pytest process**, once a run is slow enough for the timer to land in the middle of a later test.

It stayed hidden because it only reproduces in runs that live past the three-second mark. A new fuzz suite on #22 crossed that line and took the process down; three consecutive runs are clean with this change.

Fix is to write `ui/savedAutoCheckUpdates = false` into the test-scoped settings store *before* the load, so `Component.onCompleted` never starts `updateCheckTimer` and there is no thread to race. No product code changes, and it removes an unintended network dependency from CI.

## Deliberately not fixed here

The product-side half of the race: `KeyboardBridge.checkForUpdate`'s worker emits into `self` with no liveness check, and `shutdown()` does not join the thread. Practically low risk (the bridge normally outlives the process), but it is the auto-update path, so per `CLAUDE.md` it wants its own change and its own flag in review rather than riding along in a test fix.

## Test plan

- `python -m pytest tests/test_qml_compact_view.py tests/test_qml_prediction_bar.py tests/test_qml_swipe_overlay.py` — passes, no access violation across repeated runs.
- `python check.py` — ruff, format, mypy, pytest all green.

## Accessibility

No user-facing change.
