### PR TITLE
docs: name the build script that exists

### DIFF
--- a/docs/architecture/PLATFORM_ARCHITECTURE.md
+++ b/docs/architecture/PLATFORM_ARCHITECTURE.md
@@ -112,12 +112,17 @@ src/platform/
 └── pointer.py         # Was the last click ours, or somebody else's window
 
 build/
-├── alpha-osk.spec            # PyInstaller build specification
-├── alpha-osk.exe.manifest    # UIAccess manifest for EV signing
-├── alpha-osk.ico             # Application icon
-├── sign.py                   # Code signing with retry logic (matches gitconnect)
-├── build_windows.py          # Full pipeline: PyInstaller → Sign → NSIS → Verify
-└── installer.nsh             # NSIS installer customizations (shortcuts, cleanup)
+├── launcher.py               # Frozen-mode entry point, shared by every platform
+├── windows/
+│   ├── build.py              # Full pipeline: PyInstaller → Sign → NSIS → Verify
+│   ├── sign.py               # Code signing with retry logic (matches gitconnect)
+│   ├── alpha-osk.spec        # PyInstaller build specification
+│   ├── alpha-osk.exe.manifest  # UIAccess manifest for EV signing
+│   ├── alpha-osk.ico         # Application icon
+│   ├── installer.nsh         # NSIS installer customizations (shortcuts, cleanup)
+│   └── LICENSE.rtf           # Clickwrap EULA shown by the installer
+├── linux/                    # PyInstaller + optional AppImage (see build/LINUX.md)
+└── macos/                    # PyInstaller BUNDLE + optional .dmg (in progress)
 ```
 
 ### `__init__.py` — The Public API
@@ -586,7 +591,7 @@ before creating `QGuiApplication` on all platforms.
   reuse (`installer.nsh` macros, shortcut creation, old-version cleanup).
 - Free and open source.
 - Widely supported — users trust NSIS installers.
-- Easily automated from `build_windows.py` by generating `.nsi` scripts
+- Easily automated from `build/windows/build.py` by generating `.nsi` scripts
   programmatically.
 
 ### Why a Python Signing Script Instead of Inline Commands?
@@ -601,7 +606,7 @@ retry logic (matching gitconnect's `build/sign.js`).
 - Encapsulating certificate thumbprint, timestamp server, and signtool
   discovery in one file avoids duplication and mistakes.
 - The same script works standalone (`python build/windows/sign.py file.exe`) and
-  as a library imported by `build_windows.py`.
+  as a library imported by `build/windows/build.py`.
 
 ---
 
@@ -618,6 +623,7 @@ retry logic (matching gitconnect's `build/sign.js`).
 | `src/platform/macos.py` | macOS: Quartz CGEvent backend (phase 1) |
 | `src/platform/password_detect.py` | Password fields + `focused_element_token` / `caret_position_token` |
 | `src/platform/pointer.py` | `external_click_detected()`: did the last click land outside our process |
+| `src/platform/x11_window.py` | X11 window-type control (`_NET_WM_WINDOW_TYPE_DOCK`) so the window can park off-screen for "Tuck away" |
 
 ### Modified for Cross-Platform (Phase 7)
 
@@ -648,4 +654,4 @@ retry logic (matching gitconnect's `build/sign.js`).
 
 ---
 
-*Last updated: April 2026*
+*Last updated: August 2026*

--- a/docs/build/AUTO_UPDATE.md
+++ b/docs/build/AUTO_UPDATE.md
@@ -112,7 +112,7 @@ def download_and_install(url: str, filename: str) -> None:
 
 **Version tracking:**
 - Add `VERSION = "1.0.1"` to a `src/__version__.py` file
-- Read it in the updater and in `build_windows.py` (single source of truth)
+- Read it in the updater and in `build/windows/build.py` (single source of truth)
 - The NSIS installer already writes `DisplayVersion` to the registry
 
 ### Pros

--- a/docs/build/WINDOWS.md
+++ b/docs/build/WINDOWS.md
@@ -430,7 +430,7 @@ Uses the **same EV certificate and signing workflow** as
 
 ### What Gets Signed
 
-`build_windows.py` signs **every** `.exe` and `.dll` in the `dist/alpha-osk/`
+`build/windows/build.py` signs **every** `.exe` and `.dll` in the `dist/alpha-osk/`
 directory — including the bundled Python DLLs, PySide6 DLLs, and the main
 `alpha-osk.exe`.  It also signs the final NSIS installer `.exe`.
 


### PR DESCRIPTION
## Summary

Findings from a sweep of the docs against the code. Three files named `build_windows.py`, which this repo has never had; the pipeline is `build/windows/build.py`.

- **`docs/architecture/PLATFORM_ARCHITECTURE.md` contradicted itself.** Its `build/` tree listed everything at the repo's `build/` root under the wrong name, while the "All Files (Complete Inventory)" table further down already listed the same files under `build/windows/` under the right one. The tree also had no `build/linux/` or `build/macos/`, and no `build/launcher.py`, which is the frozen entry point all three share.
- **`docs/build/WINDOWS.md`** stated as present-tense fact that `build_windows.py` signs every `.exe` and `.dll`.
- **`docs/build/AUTO_UPDATE.md`** carried the same name in its implementation-plan section.
- **The platform table was missing `src/platform/x11_window.py`**, added for the off-screen "Tuck away" affordance and covered by 8 tests.
- Refreshed that file's `Last updated: April 2026` stamp, which several of the entries above it postdate.

## Related issue

No issue. Fell out of a documentation sweep.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [x] Docs only
- [ ] Build / CI / tooling
- [ ] Other (describe)

## Test plan

Docs only, no code touched.

- Re-ran the mechanical check that found this: every backticked file path in every tracked `.md` is resolved against the tree. `build_windows.py` now has zero occurrences anywhere in the repo.
- The same sweep also verified that every `module::symbol` reference in the non-research docs resolves (remaining hits are Qt / Win32 / C++-backend API names), that every quoted `function()` name exists (remaining hits are Qt and Python built-ins, plus one deferred design doc), and that every named constant the docs quote a number for matches its value in the code, which came back clean.

- [ ] `python check.py` passes locally
- [ ] Added or updated tests
- [ ] Tested in `python run.py` (not just frozen build)
- [ ] Verified on Windows
- [ ] Verified on Linux
- [ ] Verified on macOS

## Accessibility check

n/a, docs only.

## Notes for reviewers

- **Based on `feat/dictation`**, same as #41, because that is where the working tree is; nothing here depends on dictation and GitHub will retarget when the base merges.
- The `AUTO_UPDATE.md` hit is inside an "Implementation Plan" section, so it is arguably a historical record of what the plan called the file rather than a claim about today. Renamed anyway, on the grounds that nothing in the surrounding text frames it as history and a reader will grep for the name.
