### PR TITLE
chore: pin idna past PYSEC-2026-215 so the OSV scan stays green

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -44,6 +44,11 @@ Pygments==2.20.0
 # Pulled in transitively by cyclonedx-bom -> py-serializable; pin past
 # CVE-2026-41066 (GHSA-vfmq-68hx-4jfw, fixed in 6.1.0).
 lxml==6.1.1
+# Pulled in transitively by cyclonedx-bom -> cyclonedx-python-lib[validation]
+# -> jsonschema[format]; pin past PYSEC-2026-215 (GHSA-65pc-fj4g-8rjx,
+# fixed in 3.15).  osv-scanner 2.5.x resolves the transitive closure of
+# this file, so an unpinned idna is what turned the scan red.
+idna==3.19
 
 # SBOM generation (used at release time by build/{windows,linux}/build.py
 # to emit CycloneDX 1.6 SBOMs alongside the .exe / AppImage).  Not used


### PR DESCRIPTION
## Summary

Dependabot's bump of `osv-scanner-action` to 2.5.1 (#44) is red on the OSV job, and the red is real rather than stale: 2.5.1 resolves the transitive closure of `requirements-dev.txt` where 2.3.8 only read the listed pins, and it finds `idna 3.9.0` under PYSEC-2026-215 / GHSA-65pc-fj4g-8rjx (fixed in 3.15). Nothing in either requirements file pins idna; it arrives through `cyclonedx-bom -> cyclonedx-python-lib[validation] -> jsonschema[format]`.

This pins `idna==3.19` (current release, no dependencies of its own, `requires_python >= 3.9`) in the existing "Transitive dependency constraints (security)" block, the same treatment Pygments and lxml already get. That is the "fix the dep" branch of the CLAUDE.md rule rather than an `osv-scanner.toml` quarantine, and it does not touch `fail-on-vuln`.

## Type

- [x] chore

## Test plan

- `python check.py` passed on push (ruff, format, mypy linux and win32, full pytest).
- CI's OSV job on this branch still runs 2.3.8 and should stay green; the proof is #44 going green once rebased over this.

## Accessibility

No user-facing change.
