### PR TITLE
fix: write every store tempfile-then-rename so a crash cannot corrupt it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,7 @@ Edit `always_capitalize` on the language profile in `src/prediction/language.py`
 
 ## Where User Data Lives
 
+- **Every store writes through `src/atomic_write.py`** (tempfile created in the same directory, flushed and fsynced, then renamed into place), so a crash or power loss mid-write can never leave a truncated file where a good one used to be. A new persistent store must not write with a bare `open()`/`write_text`; route it through `atomic_write_text` or `atomic_write_json` instead.
 - **Settings** (layout, theme, toggles): Managed by Qt `Settings` in QML. Auto-saved on change. Stored in OS registry/config automatically by Qt.
 - **Prediction model** (learned words/phrases): Saved to disk explicitly or via auto-save on exit.
   - Windows: `%APPDATA%/alpha-osk/models/`

--- a/src/analytics.py
+++ b/src/analytics.py
@@ -18,6 +18,8 @@ from typing import Any, Dict, List, Tuple
 
 from PySide6.QtCore import QObject, Signal, Slot
 
+from .atomic_write import atomic_write_json
+
 _logger = logging.getLogger("Analytics")
 
 
@@ -295,7 +297,7 @@ class TypingAnalytics(QObject):
                 "word_freq": dict(merged_words),
                 "key_freq": dict(merged_keys),
             }
-            self._stats_path.write_text(json.dumps(data, indent=2))
+            atomic_write_json(self._stats_path, data, indent=2)
             _logger.info("Saved analytics to %s", self._stats_path)
         except (OSError, TypeError, ValueError, OverflowError) as e:
             _logger.warning("Failed to save analytics: %s", e)

--- a/src/atomic_write.py
+++ b/src/atomic_write.py
@@ -1,0 +1,80 @@
+"""Tempfile-then-rename writes, shared by every persistent store.
+
+Every loader in this codebase already rejects a corrupt file (a size cap,
+a type check, a schema fallback), which only matters if a corrupt file can
+happen in the first place. A plain ``open(path, "w")`` followed by a write
+is exactly how one does: a crash, a killed process, or a power loss between
+the open and the close leaves a truncated or half-written file in the
+place the previous good one used to be, and for ``ngram_model.json`` that
+is data the user cannot recreate. Writing to a temp file in the same
+directory and renaming it into place means the swap is atomic at the
+filesystem level: a reader (or a re-launch) sees either the old file or
+the new one, never a partial one.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def atomic_write_text(
+    path: Path,
+    text: str,
+    *,
+    encoding: str = "utf-8",
+    mode: int | None = None,
+) -> None:
+    """Write *text* to *path* atomically.
+
+    Creates the parent directory if needed, writes to a temp file in that
+    same directory (so the final rename stays on one filesystem and is
+    atomic), flushes and fsyncs before closing (a rename can otherwise
+    land before the bytes do, on some filesystems), then ``os.replace``s
+    it into place. If *mode* is given, the temp file's permissions are
+    narrowed before the rename (a no-op, swallowed, on Windows). On any
+    exception the temp file is removed and the exception re-raised; the
+    caller's own exception handling and logging are untouched by this
+    helper on purpose.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding=encoding) as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        if mode is not None:
+            try:
+                os.chmod(tmp_path, mode)
+            except OSError:
+                pass
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def atomic_write_json(
+    path: Path,
+    data: Any,
+    *,
+    indent: int | None = None,
+    ensure_ascii: bool = True,
+    mode: int | None = None,
+) -> None:
+    """Serialise *data* to JSON and write it atomically via :func:`atomic_write_text`.
+
+    Serialisation happens before any file is touched, so a value that
+    ``json.dumps`` refuses (a non-serialisable object, a circular
+    reference) never creates a temp file at all.
+    """
+    text = json.dumps(data, indent=indent, ensure_ascii=ensure_ascii)
+    atomic_write_text(path, text, mode=mode)

--- a/src/dictation/config.py
+++ b/src/dictation/config.py
@@ -33,12 +33,12 @@ from __future__ import annotations
 import base64
 import json
 import logging
-import os
 import sys
-import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+from ..atomic_write import atomic_write_json
 
 _logger = logging.getLogger(__name__)
 
@@ -334,25 +334,10 @@ class DictationConfig:
                 payload["key_protected"] = False
 
         try:
-            target.parent.mkdir(parents=True, exist_ok=True)
-            fd, tmp_name = tempfile.mkstemp(dir=str(target.parent), suffix=".tmp")
-            try:
-                with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                    json.dump(payload, fh, indent=2)
-                # Narrow the mode before the rename, so the file is never
-                # world-readable even for the instant between the two.  A
-                # no-op on Windows, where DPAPI is doing this job.
-                try:
-                    os.chmod(tmp_name, 0o600)
-                except OSError:
-                    pass
-                os.replace(tmp_name, target)
-            except BaseException:
-                try:
-                    os.unlink(tmp_name)
-                except OSError:
-                    pass
-                raise
+            # mode=0o600 narrows the file before the rename, so it is never
+            # world-readable even for the instant between the two.  A no-op
+            # on Windows, where DPAPI is doing this job.
+            atomic_write_json(target, payload, indent=2, mode=0o600)
         except OSError:
             _logger.warning("Could not save dictation settings", exc_info=True)
             return False

--- a/src/prediction/ngram_predictor.py
+++ b/src/prediction/ngram_predictor.py
@@ -14,6 +14,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Mapping, Optional, Tuple
 
+from ..atomic_write import atomic_write_json
 from .language import ENGLISH, LanguageProfile
 from .token_predictor import TokenPredictor
 
@@ -1141,9 +1142,7 @@ class NgramPredictor:
             "candidate_counts": dict(self._candidate_counts),
             "candidate_last_seen": dict(self._candidate_last_seen),
         }
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w") as f:
-            json.dump(data, f)
+        atomic_write_json(path, data)
         _logger.info("Model saved to %s", path)
 
     # Defensive bounds on saved-model shape.  A legitimate model grown

--- a/src/prediction/ppm_predictor.py
+++ b/src/prediction/ppm_predictor.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
+from ..atomic_write import atomic_write_json, atomic_write_text
+
 _logger = logging.getLogger("PPMPredictor")
 
 
@@ -363,9 +365,7 @@ class PPMPredictor:
             "root": node_to_dict(self.root),
         }
 
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w") as f:
-            json.dump(data, f)
+        atomic_write_json(path, data)
 
         _logger.info("PPM model saved to %s", path)
 
@@ -622,9 +622,8 @@ class PPMWordPredictor:
         self.ppm.save(model_path)
 
         if dict_path:
-            with open(dict_path, "w") as f:
-                for word in sorted(self.dictionary):
-                    f.write(word + "\n")
+            text = "".join(word + "\n" for word in sorted(self.dictionary))
+            atomic_write_text(dict_path, text)
 
     def get_stats(self) -> dict:
         """Get statistics."""

--- a/src/snippets.py
+++ b/src/snippets.py
@@ -58,6 +58,7 @@ import logging
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from .atomic_write import atomic_write_json
 from .platform import get_config_dir
 
 _logger = logging.getLogger("Snippets")
@@ -213,20 +214,11 @@ class SnippetStore:
 
     def save(self) -> None:
         """Write snippets to disk atomically (tempfile then rename)."""
-        self._path.parent.mkdir(parents=True, exist_ok=True)
         payload = {"version": SCHEMA_VERSION, "snippets": self._snippets}
-        tmp = self._path.with_suffix(self._path.suffix + ".saving")
         try:
-            with open(tmp, "w", encoding="utf-8") as fh:
-                json.dump(payload, fh, ensure_ascii=False, indent=2)
-            tmp.replace(self._path)
+            atomic_write_json(self._path, payload, indent=2, ensure_ascii=False)
         except OSError as exc:
             _logger.warning("Failed to save snippets: %s", exc)
-            if tmp.exists():
-                try:
-                    tmp.unlink()
-                except OSError:
-                    pass
 
     # --- Seeding -------------------------------------------------------
 

--- a/src/telemetry.py
+++ b/src/telemetry.py
@@ -23,6 +23,8 @@ import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
+from .atomic_write import atomic_write_json
+
 _logger = logging.getLogger("Telemetry")
 
 # The endpoint is read from this constant. Override per-build before
@@ -118,8 +120,7 @@ class TelemetryClient:
             "last_submit_ts": self._last_submit_ts,
         }
         try:
-            self._state_path.parent.mkdir(parents=True, exist_ok=True)
-            self._state_path.write_text(json.dumps(data, indent=2))
+            atomic_write_json(self._state_path, data, indent=2)
         except OSError as e:
             _logger.warning("failed to persist telemetry state: %s", e)
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -170,6 +171,34 @@ class TestPersistenceRoundTrip:
         a = TypingAnalytics()
         assert a._alltime_top_pick_count == 0
         assert a.get_session_stats()["alltimeTopPickRate"] == 0.0
+
+    def test_a_save_whose_rename_fails_leaves_the_old_file_loadable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """save() already swallows OSError (it must not propagate from
+        aboutToQuit / exportUserData), so the contract to check here is
+        that a failed rename never touches the previously saved file."""
+        stats_file = tmp_path / "analytics.json"
+        monkeypatch.setattr(TypingAnalytics, "_get_stats_path", staticmethod(lambda: stats_file))
+        a = TypingAnalytics()
+        a.record_prediction_selected("hello", rank=1, keystrokes_saved=3)
+        a.save()
+        good_bytes = stats_file.read_bytes()
+
+        a.record_prediction_selected("world", rank=2, keystrokes_saved=1)
+
+        def _boom(_src: object, _dst: object) -> None:
+            raise OSError("simulated rename failure")
+
+        monkeypatch.setattr(os, "replace", _boom)
+        a.save()  # must not raise
+
+        assert stats_file.read_bytes() == good_bytes
+        b = TypingAnalytics()
+        assert b._alltime_top_pick_count == 1
+        # No *.tmp sibling left behind in the config directory.
+        leftovers = [p for p in tmp_path.iterdir() if p.name != "analytics.json"]
+        assert leftovers == []
 
 
 class TestLoadCaps:

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -1,0 +1,83 @@
+"""Tests for the shared tempfile-then-rename write helper."""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.atomic_write import atomic_write_json, atomic_write_text
+
+
+class TestAtomicWriteText:
+    def test_write_creates_file_with_exact_content(self, tmp_path: Path) -> None:
+        path = tmp_path / "out.txt"
+        atomic_write_text(path, "hello world")
+        assert path.read_text(encoding="utf-8") == "hello world"
+
+    def test_write_creates_parent_directories(self, tmp_path: Path) -> None:
+        path = tmp_path / "nested" / "dir" / "out.txt"
+        atomic_write_text(path, "content")
+        assert path.exists()
+        assert path.read_text(encoding="utf-8") == "content"
+
+    def test_write_over_existing_file_replaces_it(self, tmp_path: Path) -> None:
+        path = tmp_path / "out.txt"
+        atomic_write_text(path, "first")
+        atomic_write_text(path, "second")
+        assert path.read_text(encoding="utf-8") == "second"
+
+    def test_no_leftover_tmp_files_after_a_successful_write(self, tmp_path: Path) -> None:
+        path = tmp_path / "out.txt"
+        atomic_write_text(path, "content")
+        leftovers = [p for p in tmp_path.iterdir() if p.name != "out.txt"]
+        assert leftovers == []
+
+    def test_failed_rename_leaves_the_original_content_intact(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = tmp_path / "out.txt"
+        atomic_write_text(path, "original")
+
+        def _boom(_src: object, _dst: object) -> None:
+            raise OSError("simulated rename failure")
+
+        monkeypatch.setattr(os, "replace", _boom)
+
+        with pytest.raises(OSError):
+            atomic_write_text(path, "new content")
+
+        # The original file is untouched, and no *.tmp sibling survives
+        # the failed attempt.
+        assert path.read_text(encoding="utf-8") == "original"
+        leftovers = [p for p in tmp_path.iterdir() if p.name != "out.txt"]
+        assert leftovers == []
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX file mode only")
+    def test_mode_is_applied_on_posix(self, tmp_path: Path) -> None:
+        path = tmp_path / "secret.txt"
+        atomic_write_text(path, "shh", mode=0o600)
+        actual = stat.S_IMODE(path.stat().st_mode)
+        assert actual == 0o600
+
+
+class TestAtomicWriteJson:
+    def test_write_creates_file_with_exact_content(self, tmp_path: Path) -> None:
+        path = tmp_path / "out.json"
+        atomic_write_json(path, {"a": 1, "b": [1, 2, 3]})
+        assert path.read_text(encoding="utf-8") == '{"a": 1, "b": [1, 2, 3]}'
+
+    def test_serialisation_failure_creates_no_file_and_no_temp(self, tmp_path: Path) -> None:
+        path = tmp_path / "out.json"
+
+        class Unserialisable:
+            pass
+
+        with pytest.raises(TypeError):
+            atomic_write_json(path, {"bad": Unserialisable()})
+
+        assert not path.exists()
+        assert list(tmp_path.iterdir()) == []

--- a/tests/test_ngram_predictor.py
+++ b/tests/test_ngram_predictor.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+
+import pytest
 
 from src.prediction.ngram_predictor import NgramPredictor
 
@@ -206,6 +209,39 @@ class TestNgramPersistence:
         loaded.load(path)
         loaded_preds = loaded.predict("the ", n=5)
         assert original_preds == loaded_preds
+
+    def test_a_save_whose_rename_fails_leaves_the_old_model_loadable(
+        self, tmp_model_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A crash mid-write must not corrupt the model a user cannot
+        recreate: the previous good save has to survive a failed rename
+        untouched, exactly as it did before this one was attempted."""
+        path = tmp_model_dir / "ngram.json"
+        predictor = NgramPredictor()
+        predictor.learn("zqxvex wqjplo brkzun")
+        predictor.save(path)
+        good_bytes = path.read_bytes()
+        baseline = NgramPredictor()
+        baseline.load(path)
+        baseline_unigrams = dict(baseline.unigrams)
+
+        predictor.learn("zqxvex wqjplo brkzun again and again")
+
+        def _boom(_src: object, _dst: object) -> None:
+            raise OSError("simulated rename failure")
+
+        monkeypatch.setattr(os, "replace", _boom)
+        with pytest.raises(OSError):
+            predictor.save(path)
+
+        # The file on disk is byte-identical to the last good save.
+        assert path.read_bytes() == good_bytes
+        loaded = NgramPredictor()
+        loaded.load(path)
+        assert dict(loaded.unigrams) == baseline_unigrams
+        # No *.tmp sibling left behind in the model directory.
+        leftovers = [p for p in tmp_model_dir.iterdir() if p.name != "ngram.json"]
+        assert leftovers == []
 
 
 class TestNgramTokenization:


### PR DESCRIPTION
## Summary

- Of the six persistent stores, only `snippets.json` and `dictation.json` were written tempfile-then-rename. `ngram_model.json`, `ppm_model.json`, `analytics.json` and `telemetry.json` wrote straight through `open()` / `write_text`, so a crash or power loss mid-write could leave a truncated file where the good one had been. Every loader here already rejects a corrupt file; this is how one gets created, and the n-gram model is the one artifact a user cannot recreate.
- New `src/atomic_write.py` (`atomic_write_text` / `atomic_write_json`: temp file in the same directory, flush + fsync, `os.replace`, temp removed on any failure, callers keep their own exception handling and logging). All six stores route through it; the two hand-rolled copies in `snippets.py` and `dictation/config.py` are replaced, dictation keeping its `mode=0o600` narrowing before the rename.

Sequence item 3 of `docs/architecture/STRUCTURAL_REVIEW.md`.

## Related issue

No issue; follows the structural review recorded in #53.

## Type of change

- [x] Bug fix

## Test plan

- [x] `python check.py` passes locally (run twice)
- [x] Added `tests/test_atomic_write.py` (creation, parent dirs, overwrite, no leftover temp, a failed rename leaves the original intact with no `*.tmp` sibling, POSIX mode, a serialisation failure creates nothing) and a failed-rename regression test each for `NgramPredictor.save` and `TypingAnalytics.save` asserting the previous good file survives byte for byte.

## Accessibility check

n/a.

## Notes for reviewers

- `fsync` is new relative to the old snippets and dictation copies. A rename can land before the bytes do on some filesystems, which is the exact failure this exists to prevent, and the cost at these file sizes is milliseconds on a save that happens at exit or on demand.
- `PPMWordPredictor.save`'s `dict_path` write has no caller in the codebase; it is routed through the helper anyway so there is no bare write left to copy from.
- CLAUDE.md's "Where User Data Lives" now says a new store must not write with a bare `open()`.
