### PR TITLE
test: key the QSettings test scope per checkout, not just per worker

### DIFF
--- a/tests/qt_settings_scope.py
+++ b/tests/qt_settings_scope.py
@@ -32,13 +32,37 @@ while each module's explicit ``QSettings(TEST_ORG, TEST_APP)`` calls
 look wherever their own copy says.  Diverge them and the tests read a
 different scope than the QML wrote to, which fails as a persistence
 bug rather than as a configuration mistake.
+
+* **It must be per checkout, too.**  Worker names are ``gw0``..``gwN``
+  in every run, so two checkouts of this repo (git worktrees, say, each
+  gating a branch at the same time) collide exactly as two workers did,
+  and it shows up the same way: a window width that "drifted across
+  restarts", in whichever run lost the race.  Seen on 2026-09-02 with
+  four worktrees running ``check.py`` at once.  The scope therefore
+  also carries a short stable hash of the checkout path.  ``crc32``
+  rather than ``hash()``, for the reason ``conftest.py`` gives for the
+  shard hash: string hashing is salted per process.
 """
 
 from __future__ import annotations
 
 import os
+import zlib
+from pathlib import Path
+
+
+def scope_org(checkout: Path, worker: str) -> str:
+    """The organisation name for one (checkout, xdist worker) pair.
+
+    Every part is alphanumeric or a hyphen, so the value is safe as both
+    a registry key and a directory name.
+    """
+    tag = f"{zlib.crc32(str(checkout.resolve()).encode('utf-8')) & 0xFFFFFFFF:08x}"
+    return "-".join(part for part in ("alpha-osk-tests", tag, worker) if part)
+
 
 _XDIST_WORKER = os.environ.get("PYTEST_XDIST_WORKER", "")
+_CHECKOUT = Path(__file__).resolve().parent.parent
 
-TEST_ORG = f"alpha-osk-tests-{_XDIST_WORKER}" if _XDIST_WORKER else "alpha-osk-tests"
+TEST_ORG = scope_org(_CHECKOUT, _XDIST_WORKER)
 TEST_APP = "Alpha-OSK-Tests"

--- a/tests/test_qt_settings_scope.py
+++ b/tests/test_qt_settings_scope.py
@@ -1,0 +1,40 @@
+"""The QSettings scope the headless QML tests write to is private per checkout."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.qt_settings_scope import TEST_APP, TEST_ORG, scope_org
+
+
+class TestTheScopeIsPrivateToTheRun:
+    """Two runs that share a scope wipe each other's keys mid-test, and
+    that surfaces as the persistence bug those tests exist to catch, not
+    as an obvious collision.  These pin the two axes the scope is keyed
+    on: the xdist worker, and the checkout the tests live in."""
+
+    def test_two_checkouts_get_different_scopes(self, tmp_path: Path) -> None:
+        a = tmp_path / "worktree-a"
+        b = tmp_path / "worktree-b"
+        assert scope_org(a, "gw0") != scope_org(b, "gw0")
+
+    def test_two_workers_in_one_checkout_get_different_scopes(self, tmp_path: Path) -> None:
+        assert scope_org(tmp_path, "gw0") != scope_org(tmp_path, "gw1")
+
+    def test_the_scope_is_stable_for_one_pair(self, tmp_path: Path) -> None:
+        assert scope_org(tmp_path, "gw3") == scope_org(tmp_path, "gw3")
+
+    def test_the_serial_run_has_a_scope_of_its_own(self, tmp_path: Path) -> None:
+        serial = scope_org(tmp_path, "")
+        assert serial != scope_org(tmp_path, "gw0")
+        assert not serial.endswith("-")
+
+    def test_the_value_is_a_safe_registry_key_and_directory_name(self, tmp_path: Path) -> None:
+        for org in (scope_org(tmp_path, ""), scope_org(tmp_path, "gw12"), TEST_ORG):
+            assert org.replace("-", "").isalnum(), org
+        assert TEST_APP.replace("-", "").isalnum()
+
+    def test_this_checkout_is_in_the_live_scope(self) -> None:
+        here = Path(__file__).resolve().parent.parent
+        # Whatever worker this is running under, the checkout half is the same.
+        assert TEST_ORG.startswith(scope_org(here, ""))


### PR DESCRIPTION
## Summary

- The headless QML tests write to a process-external QSettings scope keyed only by the xdist worker name (`gw0`..`gwN`). Two checkouts of the repo running the suite at once (git worktrees each gating a branch) therefore share scopes and clear each other's keys mid-test. It surfaces as the "window width drifted across restarts" failure the persistence tests exist to catch, in whichever run lost the race. Seen today with four worktrees running `check.py` in parallel.
- The organisation name now also carries a `crc32` of the checkout path (`crc32`, not `hash()`, for the reason `conftest.py` gives for the shard hash). `scope_org(checkout, worker)` is the one function that builds it.

## Related issue

No issue; found while running the structural-review refactors in parallel worktrees.

## Type of change

- [x] Build / CI / tooling

## Test plan

- [x] `tests/test_qt_settings_scope.py`: two checkouts differ, two workers differ, one pair is stable, the serial run has its own scope, the value is a safe registry key, and the live `TEST_ORG` carries this checkout's tag.
- [x] All six headless QML suites pass under `-n auto` with the new keying.

## Accessibility check

n/a.

## Notes for reviewers

Registry litter stays bounded: one scope set per checkout rather than per run.
