### PR TITLE
chore(deps): bump fast-uri to 3.1.7 so the OSV gate stays green

### DIFF
--- a/backend/cf-worker/package-lock.json
+++ b/backend/cf-worker/package-lock.json
@@ -1954,9 +1954,9 @@
       "optional": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- Four advisories were published today against `fast-uri` 3.1.5 (GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp), a transitive dev dependency of the Cloudflare telemetry worker, so the required OSV check fails on every open pull request. `npm update fast-uri --package-lock-only` resolves to 3.1.7. Lockfile only; nothing in the installer is affected.

## Related issue

No issue. Same shape as #52 (idna).

## Type of change

- [x] Build / CI / tooling

## Test plan

- [x] The OSV Scanner check on this PR is the test.

## Accessibility check

n/a.
