### PR TITLE
refactor: move telemetry off the bridge onto its own context property

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ User clicks key (QML)
 | Path | What |
 |------|------|
 | `src/keyboard_bridge.py` | Central bridge: key handling, modifiers, context tracking, predictions |
+| `src/telemetry_bridge.py` | `TelemetryBridge` - QML-facing wrapper around opt-in telemetry, registered as its own context property (see *Opt-in Telemetry*) |
 | `src/keyboard_app.py` | App launcher: QML engine, window flags, auto-save on exit |
 | `src/platform/` | OS abstraction - `linux.py` (xdotool/ydotool), `windows.py` (SendInput), `password_detect.py` |
 | `src/platform/__init__.py` | Platform detection, `get_config_dir()`, `get_model_dir()` |
@@ -401,6 +402,8 @@ Regression coverage: `tests/test_data_export.py::TestInspect::test_zip_slip_reje
 ## QML <-> Python Bridge Pattern
 
 QML calls Python via `@Slot` methods on `KeyboardBridge`; Python emits `Signal`s back. The keystroke round trip is the one diagrammed under *Architecture Overview*, and it ends with `self.predictionsChanged.emit(predictions)`, which QML picks up as a binding on the `keyboard.predictions` property rather than as a callback.
+
+There are now **two** QML context properties registered in `keyboard_app.py`: `keyboard` (`KeyboardBridge`, everything above) and `telemetry` (`TelemetryBridge`, see *Opt-in Telemetry*) - the first feature surface pulled off the bridge per `docs/architecture/STRUCTURAL_REVIEW.md` section 3.1. A future split follows the same shape: its own `QObject` wrapper, its own context property name, registered next to `keyboard` in `keyboard_app.py` and in `tests/qml_context.py::install_context_properties` for the headless QML test fixtures.
 
 ## Caps Lock vs. Shift
 
@@ -1246,11 +1249,13 @@ Design: `docs/architecture/TELEMETRY.md`. User-facing privacy: `docs/PRIVACY.md`
 
 **Off by default.** When enabled (Settings -> Data & Privacy -> Privacy -> "Share anonymous usage stats"), the client sends a weekly POST containing nine integers: `anon_id`, `app_version`, `os`, `keystrokes`, `words`, `predictions`, `keystrokes_saved`, `minutes`, `sessions`, `prediction_offers`. These are exactly the lifetime counters already shown on the Analytics dashboard. **Never sent**: content, word frequencies, key frequencies, IP, hostname, or any per-session breakdown.
 
+**Reached from QML as its own context property, not through the bridge.** `src/telemetry_bridge.py::TelemetryBridge` owns the `TelemetryClient` and the hourly submit timer, and is registered in `keyboard_app.py` as `telemetry` (alongside `keyboard`, the `KeyboardBridge`) - see *QML <-> Python Bridge Pattern*. `UnifiedSettingsPanel.qml` calls `telemetry.getEnabled()` / `telemetry.setEnabled(c)` / `telemetry.forgetData()`; `KeyboardBridge` no longer references telemetry at all. The headless QML test fixtures register both context properties through one helper, `tests/qml_context.py::install_context_properties`, rather than each hand-rolling `setContextProperty` calls.
+
 Files, endpoint config, anon_id lifecycle, submit cadence, and the worker schema are all detailed in `docs/architecture/TELEMETRY.md`. Load-bearing facts:
 - **`DEFAULT_ENDPOINT` in `src/telemetry.py` is the empty string** - while empty the client silently no-ops every submit (consent toggle still works, no data leaves the machine). Set it per-build before shipping a telemetry-enabled release; the Windows checklist (`docs/build/WINDOWS.md` step 2a) gates on this.
 - **anon_id is cleared on opt-out**, so re-opt-in gets a fresh UUID4 and prior contributions can't be linked. "Delete my contributed data" POSTs to `/v1/forget`. (This is why the Data Backup archive deliberately excludes `telemetry.json`.)
-- **`TelemetryClient` is the source of truth for the consent flag** - `UnifiedSettingsPanel.qml` queries the bridge on mount; **don't** mirror it into `appSettings`.
-- **Cadence**: weekly `QTimer` (1-hour tick, 7-day window check) plus `submit_on_quit()` from `shutdown()` (60 s anti-spam guard). All paths gated on `enabled AND endpoint AND anon_id`; failures retry `[5s, 30s, 120s]` then drop silently.
+- **`TelemetryClient` is the source of truth for the consent flag** - `UnifiedSettingsPanel.qml` queries `telemetry` on mount; **don't** mirror it into `appSettings`.
+- **Cadence**: weekly `QTimer` (1-hour tick, 7-day window check) plus `submit_on_quit()` from `TelemetryBridge.shutdown()` (60 s anti-spam guard), called from `keyboard_app.py`'s quit sequence before `bridge.shutdown()` - the same relative order the two had when both lived inside the bridge's own `shutdown()`. All paths gated on `enabled AND endpoint AND anon_id`; failures retry `[5s, 30s, 120s]` then drop silently.
 - **Privacy mode needs no special handling** - it already suppresses learning/tracking upstream, so password activity never enters the counters telemetry forwards.
 - **Worker-side rate limiting** (`backend/cf-worker/src/worker.ts`): two layers, both keyed on `anon_id` and never on a request header. An edge `RATE_LIMITER` binding gates by `submit:<anon_id>`, and a `SUBMIT_COOLDOWN_SECONDS` (3600s) cooldown is enforced inside the D1 upserts themselves. The cooldown `WHERE` clause is on **both** statements in `handleSubmit` (`users` and `submissions_latest`); gating only the second left `users` taking a write per request, so the cooldown bounded half the write path. The clause gates `DO UPDATE` only, so a first-ever submission for an id still lands immediately. Every reject path, rate-limited, cooled-down, or a `/v1/forget` for an id that never existed, returns the same 204 a success would, so a response can never be used as an existence oracle for a given `anon_id`. `app_version` and `os` are validated against a semver regex and a platform enum before being written. Neither layer stops an attacker cycling through many fake `anon_id`s; that needs IP-based throttling, out of scope here.
 - **Not telemetry**: auto-update version checks (GitHub Releases requests) and the planned federated-learning feature (its own opt-in + DP-noise design). Keep them conceptually separate.

--- a/docs/architecture/TELEMETRY.md
+++ b/docs/architecture/TELEMETRY.md
@@ -63,7 +63,7 @@ If the user clears their config dir or reinstalls, they get a new anon_id and th
 
 Two paths, both gated on consent:
 
-1. **Weekly QTimer**: 7-day interval, fires from `KeyboardBridge` once telemetry is enabled. First submission lands ~7 days after opt-in (not immediately on toggle), so a user toggling out of curiosity doesn't accidentally send anything.
+1. **Weekly QTimer**: 7-day interval, fires from `TelemetryBridge` (`src/telemetry_bridge.py`, registered in QML as the `telemetry` context property) once telemetry is enabled. First submission lands ~7 days after opt-in (not immediately on toggle), so a user toggling out of curiosity doesn't accidentally send anything.
 2. **`aboutToQuit`**: if any counter has changed since the last successful submit, send before exit.
 
 If the user opts in, types for two days, then opts out: nothing was sent because the weekly window hadn't elapsed. This is fine. The counters are lifetime totals, so a delayed submit just means the public aggregate lags reality by up to a week.

--- a/qml/components/UnifiedSettingsPanel.qml
+++ b/qml/components/UnifiedSettingsPanel.qml
@@ -1778,10 +1778,10 @@ Item {
                                     // TelemetryClient is authoritative.
                                     checked: false
                                     Component.onCompleted: {
-                                        if (keyboard) checked = keyboard.getTelemetryEnabled()
+                                        if (telemetry) checked = telemetry.getEnabled()
                                     }
                                     onToggled: function(c) {
-                                        if (keyboard) keyboard.setTelemetryEnabled(c)
+                                        if (telemetry) telemetry.setEnabled(c)
                                     }
                                 }
 
@@ -1848,7 +1848,7 @@ Item {
                                                 forgetBtn.confirmStep = 1
                                                 forgetResetTimer.restart()
                                             } else if (forgetBtn.confirmStep === 1) {
-                                                if (keyboard) keyboard.forgetTelemetryData()
+                                                if (telemetry) telemetry.forgetData()
                                                 forgetBtn.confirmStep = 2
                                                 forgetResetTimer.restart()
                                             }

--- a/src/keyboard_app.py
+++ b/src/keyboard_app.py
@@ -66,6 +66,7 @@ from .platform import (
     get_config_dir,
     get_platform_info,
 )
+from .telemetry_bridge import TelemetryBridge
 
 _logger = logging.getLogger("KeyboardApp")
 
@@ -1164,6 +1165,17 @@ def main() -> int:
     # Create the bridge (auto-detects platform key synthesizer)
     bridge = KeyboardBridge()
 
+    # Telemetry lives on its own QObject rather than on the bridge -- see
+    # docs/architecture/STRUCTURAL_REVIEW.md section 3.1.  Parented to the
+    # bridge so its lifetime is tied to a live C++ owner rather than to
+    # whichever Python name happens to still reference it.
+    telemetry = TelemetryBridge(
+        bridge.analytics.get_session_stats,
+        app_version=__version__,
+        os_name=CURRENT_PLATFORM,
+        parent=bridge,
+    )
+
     if not bridge.synthAvailable:
         if CURRENT_PLATFORM == "linux":
             _logger.warning(
@@ -1196,6 +1208,7 @@ def main() -> int:
 
     # Expose bridge to QML
     engine.rootContext().setContextProperty("keyboard", bridge)
+    engine.rootContext().setContextProperty("telemetry", telemetry)
 
     # Load QML
     main_qml = qml_path()
@@ -1248,6 +1261,10 @@ def main() -> int:
             _logger.info("Auto-saving prediction model on exit...")
             bridge.savePredictionModel()
         bridge.saveAnalytics()
+        # Telemetry's own timer-stop-then-submit runs first, matching the
+        # relative order it had when it was the first thing bridge.shutdown()
+        # did, before bridge.shutdown() tears down its own timers/modifiers.
+        telemetry.shutdown()
         bridge.shutdown()
 
     app.aboutToQuit.connect(_on_about_to_quit)

--- a/src/keyboard_bridge.py
+++ b/src/keyboard_bridge.py
@@ -49,7 +49,6 @@ from .prediction import HybridPredictor
 from .prediction.fuzzy_recognizer import positions_from_layout
 from .prediction.token_predictor import TokenPredictor
 from .snippets import MAX_SNIPPETS, SNIPPET_COLORS, SnippetStore
-from .telemetry import TelemetryClient
 from .text_patterns import (
     detect_snippet_candidate,
     is_email,
@@ -731,24 +730,6 @@ class KeyboardBridge(QObject):
         # mutation, so there is no on-quit save path to wire up.
         self._snippets = SnippetStore()
         self._snippets.load()
-
-        # Telemetry — opt-in, off by default.  Pulls lifetime counters
-        # from the analytics dashboard's getter so there is one source
-        # of truth.  Settings → Data & Privacy → Privacy controls it; the QTimer below
-        # checks once an hour whether the weekly window has elapsed.
-        # See docs/architecture/TELEMETRY.md (design) and docs/PRIVACY.md (user-facing).
-        self._telemetry = TelemetryClient(
-            analytics_provider=self._analytics.get_session_stats,
-            app_version=APP_VERSION,
-            os_name=CURRENT_PLATFORM,
-        )
-        self._telemetry_timer = QTimer(self)
-        # Hourly tick is plenty: maybe_submit() short-circuits unless
-        # the 7-day window has elapsed, and we want the timer to be
-        # cheap (a no-op call costs ~5 microseconds).
-        self._telemetry_timer.setInterval(60 * 60 * 1000)
-        self._telemetry_timer.timeout.connect(self._telemetry.maybe_submit)
-        self._telemetry_timer.start()
 
         # Context tracking for predictions
         self._context_buffer = ""
@@ -4212,21 +4193,12 @@ class KeyboardBridge(QObject):
             getattr(self, "_password_timer", None),
             getattr(self, "_foreground_timer", None),
             getattr(self, "_click_timer", None),
-            getattr(self, "_telemetry_timer", None),
         ):
             if timer is not None:
                 try:
                     timer.stop()
                 except RuntimeError:
                     pass  # already deleted by Qt; harmless
-
-        # Last-chance telemetry submit on the on-quit path.  Internally
-        # gated on consent + endpoint + anon_id + a 60 s anti-spam
-        # window, so calling it unconditionally here is safe.
-        try:
-            self._telemetry.submit_on_quit()
-        except Exception as e:
-            _logger.info("telemetry on-quit submit failed: %s", e)
 
         # Release any held modifier — sticky or right-click-locked — so
         # quitting with one "active" doesn't pin it at the OS level.
@@ -4441,6 +4413,16 @@ class KeyboardBridge(QObject):
     def autoSaveOnExit(self) -> bool:
         """Whether to auto-save prediction model on exit."""
         return self._auto_save_on_exit
+
+    @property
+    def analytics(self) -> TypingAnalytics:
+        """Read-only access to the analytics store.
+
+        For objects that live outside the bridge (``TelemetryBridge``,
+        which needs ``get_session_stats`` to build its payload) rather
+        than reaching into the private ``_analytics`` attribute.
+        """
+        return self._analytics
 
     # --- Privacy Mode ---
 
@@ -4915,34 +4897,6 @@ class KeyboardBridge(QObject):
         """Enable/disable automatic password field detection."""
         self._password_detect_enabled = enabled
         _logger.info("Password field detection: %s", enabled)
-
-    # --- Telemetry (opt-in usage stats) ---
-
-    @Slot(result=bool)
-    def getTelemetryEnabled(self) -> bool:
-        """QML reads this on Settings panel mount to render the toggle."""
-        return self._telemetry.enabled
-
-    @Slot(bool)
-    def setTelemetryEnabled(self, enabled: bool) -> None:
-        """Toggle the opt-in telemetry pipeline.  Off → On generates a
-        new anon_id and starts the weekly clock; On → Off clears the
-        anon_id (so future opt-in cycles cannot be linked).  See
-        docs/PRIVACY.md.
-        """
-        if enabled:
-            self._telemetry.enable()
-        else:
-            self._telemetry.disable()
-        _logger.info("Telemetry consent: %s", enabled)
-
-    @Slot(result=bool)
-    def forgetTelemetryData(self) -> bool:
-        """Ask the server to delete this user's contributed row.
-        Triggered by the 'Delete my contributed data' button in
-        Settings → Data & Privacy → Privacy.  Returns True if the request was sent.
-        """
-        return self._telemetry.forget()
 
     def _get_privacy_mode(self) -> bool:
         return self._privacy_mode

--- a/src/telemetry_bridge.py
+++ b/src/telemetry_bridge.py
@@ -1,0 +1,111 @@
+"""
+QML-facing wrapper around the opt-in telemetry pipeline.
+
+``KeyboardBridge`` already carries seventeen distinct concerns (see
+``docs/architecture/STRUCTURAL_REVIEW.md`` section 3.1); telemetry was one
+of the cheapest to pull off because it already delegated everything real
+to ``TelemetryClient`` and touched only three call sites in QML. This
+module is the first cut along that seam - a measurement of what moving a
+bolt-on feature surface off the bridge costs, not a commitment to move the
+rest of them.
+
+``TelemetryClient`` (in ``src/telemetry.py``) remains the source of truth
+for the consent flag and everything else about *what* gets sent; this
+class only owns the QObject plumbing QML needs to reach it - the hourly
+submit timer and the three pass-through slots.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, Optional
+
+from PySide6.QtCore import QObject, QTimer, Slot
+
+from .telemetry import TelemetryClient
+
+_logger = logging.getLogger("TelemetryBridge")
+
+
+class TelemetryBridge(QObject):
+    """Owns the ``TelemetryClient`` and the hourly maybe-submit timer.
+
+    Registered as the ``telemetry`` QML context property in
+    ``keyboard_app.py``, alongside ``keyboard`` (the ``KeyboardBridge``).
+    """
+
+    def __init__(
+        self,
+        analytics_provider: Optional[Callable[[], Dict[str, Any]]],
+        *,
+        app_version: str = "",
+        os_name: str = "",
+        parent: Optional[QObject] = None,
+    ) -> None:
+        super().__init__(parent)
+
+        # Telemetry - opt-in, off by default.  Pulls lifetime counters
+        # from the analytics dashboard's getter so there is one source
+        # of truth.  Settings → Data & Privacy → Privacy controls it; the QTimer below
+        # checks once an hour whether the weekly window has elapsed.
+        # See docs/architecture/TELEMETRY.md (design) and docs/PRIVACY.md (user-facing).
+        self._telemetry = TelemetryClient(
+            analytics_provider=analytics_provider,
+            app_version=app_version,
+            os_name=os_name,
+        )
+        self._telemetry_timer = QTimer(self)
+        # Hourly tick is plenty: maybe_submit() short-circuits unless
+        # the 7-day window has elapsed, and we want the timer to be
+        # cheap (a no-op call costs ~5 microseconds).
+        self._telemetry_timer.setInterval(60 * 60 * 1000)
+        self._telemetry_timer.timeout.connect(self._telemetry.maybe_submit)
+        self._telemetry_timer.start()
+
+    # --- Telemetry (opt-in usage stats) ---
+
+    @Slot(result=bool)
+    def getEnabled(self) -> bool:
+        """QML reads this on Settings panel mount to render the toggle."""
+        return self._telemetry.enabled
+
+    @Slot(bool)
+    def setEnabled(self, enabled: bool) -> None:
+        """Toggle the opt-in telemetry pipeline.  Off → On generates a
+        new anon_id and starts the weekly clock; On → Off clears the
+        anon_id (so future opt-in cycles cannot be linked).  See
+        docs/PRIVACY.md.
+        """
+        if enabled:
+            self._telemetry.enable()
+        else:
+            self._telemetry.disable()
+        _logger.info("Telemetry consent: %s", enabled)
+
+    @Slot(result=bool)
+    def forgetData(self) -> bool:
+        """Ask the server to delete this user's contributed row.
+        Triggered by the 'Delete my contributed data' button in
+        Settings → Data & Privacy → Privacy.  Returns True if the request was sent.
+        """
+        return self._telemetry.forget()
+
+    def shutdown(self) -> None:
+        """Stop the submit timer and make a last-chance on-quit submit.
+
+        Called from the app's quit sequence, before ``KeyboardBridge``'s
+        own ``shutdown()``, to preserve the relative order the two steps
+        had when they were both part of the bridge's ``shutdown()``.
+        """
+        try:
+            self._telemetry_timer.stop()
+        except RuntimeError:
+            pass  # already deleted by Qt; harmless
+
+        # Last-chance telemetry submit on the on-quit path.  Internally
+        # gated on consent + endpoint + anon_id + a 60 s anti-spam
+        # window, so calling it unconditionally here is safe.
+        try:
+            self._telemetry.submit_on_quit()
+        except Exception as e:
+            _logger.info("telemetry on-quit submit failed: %s", e)

--- a/tests/qml_context.py
+++ b/tests/qml_context.py
@@ -1,0 +1,56 @@
+"""The QML context properties every headless QML test needs registered.
+
+``Main.qml`` reads two Python objects out of the QML root context:
+``keyboard`` (the ``KeyboardBridge``) and, since telemetry moved off the
+bridge (``docs/architecture/STRUCTURAL_REVIEW.md`` section 3.1),
+``telemetry`` (a ``TelemetryBridge``). Seven fixtures across the headless
+QML test modules each called ``setContextProperty("keyboard", bridge)``
+by hand; without this helper, adding ``telemetry`` would have meant
+editing all seven, and the next context property after that would mean
+editing eight. One call here keeps it a one-edit change.
+
+``install_context_properties`` builds a ``TelemetryBridge`` off the given
+bridge when the caller does not already have one, and parents it to that
+bridge. Parenting -- not returning it for the caller to hold in a local
+variable -- is deliberate: several of these fixtures build the QML root
+inside a closure (``qml_root_factory``, ``picker_factory``, the
+``_boot`` helper in ``test_qml_ui_state_fuzz.py``) and only return
+``(root, warnings, bridge)`` to the test. A ``TelemetryBridge`` with no
+Python reference and no Qt parent is garbage-collected the moment
+``install_context_properties`` returns, and QML's ``telemetry`` context
+property goes null -- the same trap the ``_boot`` docstring already
+documents for the bridge itself. Tying its lifetime to the bridge's,
+the way ``QTimer(self)`` ties every timer's lifetime to its owner
+throughout this codebase, means every fixture gets a live ``telemetry``
+for free.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from PySide6.QtQml import QQmlApplicationEngine
+
+from src.keyboard_bridge import KeyboardBridge
+from src.telemetry_bridge import TelemetryBridge
+
+
+def install_context_properties(
+    engine: QQmlApplicationEngine,
+    bridge: KeyboardBridge,
+    *,
+    telemetry: Optional[TelemetryBridge] = None,
+) -> TelemetryBridge:
+    """Register ``keyboard`` and ``telemetry`` on ``engine``'s root context.
+
+    Returns the ``TelemetryBridge`` that was registered (the one passed
+    in, or a freshly built one parented to ``bridge``), so a test that
+    wants to drive it directly (toggle consent, force a submit) doesn't
+    have to reach back into ``bridge``, which no longer has any telemetry
+    on it.
+    """
+    if telemetry is None:
+        telemetry = TelemetryBridge(bridge.analytics.get_session_stats, parent=bridge)
+    engine.rootContext().setContextProperty("keyboard", bridge)
+    engine.rootContext().setContextProperty("telemetry", telemetry)
+    return telemetry

--- a/tests/test_qml_compact_view.py
+++ b/tests/test_qml_compact_view.py
@@ -52,6 +52,7 @@ from src.keyboard_bridge import KeyboardBridge  # noqa: E402
 REPO_ROOT = Path(__file__).resolve().parent.parent
 QML_MAIN = REPO_ROOT / "qml" / "Main.qml"
 
+from tests.qml_context import install_context_properties  # noqa: E402
 from tests.qt_settings_scope import TEST_APP, TEST_ORG  # noqa: E402
 
 # Qt Quick Controls emits this for every Rectangle-customised control in the
@@ -114,7 +115,7 @@ def qml_root(qapp):
 
     engine = QQmlApplicationEngine()
     engine.warnings.connect(lambda errs: warnings.extend(e.toString() for e in errs))
-    engine.rootContext().setContextProperty("keyboard", bridge)
+    install_context_properties(engine, bridge)
     engine.load(QUrl.fromLocalFile(str(QML_MAIN)))
 
     assert engine.rootObjects(), "qml/Main.qml failed to load:\n  " + "\n  ".join(warnings)
@@ -156,7 +157,7 @@ def qml_root_factory(qapp):
 
         engine = QQmlApplicationEngine()
         engine.warnings.connect(lambda errs: warnings.extend(e.toString() for e in errs))
-        engine.rootContext().setContextProperty("keyboard", bridge)
+        install_context_properties(engine, bridge)
         engine.load(QUrl.fromLocalFile(str(QML_MAIN)))
         assert engine.rootObjects(), "qml/Main.qml failed to load:\n  " + "\n  ".join(warnings)
         engines.append(engine)

--- a/tests/test_qml_dictation.py
+++ b/tests/test_qml_dictation.py
@@ -78,6 +78,7 @@ QML_MAIN = REPO_ROOT / "qml" / "Main.qml"
 # All the headless QML modules must share one QSettings scope, keyed per
 # xdist worker. See tests/qt_settings_scope.py for why a per-module copy of
 # the literal is a trap.
+from tests.qml_context import install_context_properties  # noqa: E402
 from tests.qt_settings_scope import TEST_APP, TEST_ORG  # noqa: E402
 
 IGNORED_WARNING_FRAGMENTS = ("does not support customization",)
@@ -177,7 +178,7 @@ def qml_root(qapp):
 
     engine = QQmlApplicationEngine()
     engine.warnings.connect(lambda errs: warnings.extend(e.toString() for e in errs))
-    engine.rootContext().setContextProperty("keyboard", bridge)
+    install_context_properties(engine, bridge)
     engine.load(QUrl.fromLocalFile(str(QML_MAIN)))
 
     assert engine.rootObjects(), "qml/Main.qml failed to load:\n  " + "\n  ".join(warnings)

--- a/tests/test_qml_prediction_bar.py
+++ b/tests/test_qml_prediction_bar.py
@@ -55,6 +55,7 @@ QML_MAIN = REPO_ROOT / "qml" / "Main.qml"
 # Re-exported so the existing references below keep reading TEST_ORG /
 # TEST_APP.  All four QML modules must share one scope. See
 # tests/qt_settings_scope.py for why a per-module copy is a trap.
+from tests.qml_context import install_context_properties  # noqa: E402
 from tests.qt_settings_scope import TEST_APP, TEST_ORG  # noqa: E402
 
 IGNORED_WARNING_FRAGMENTS = ("does not support customization",)
@@ -159,7 +160,7 @@ def qml_root(qapp):
 
     engine = QQmlApplicationEngine()
     engine.warnings.connect(lambda errs: warnings.extend(e.toString() for e in errs))
-    engine.rootContext().setContextProperty("keyboard", bridge)
+    install_context_properties(engine, bridge)
     engine.load(QUrl.fromLocalFile(str(QML_MAIN)))
 
     assert engine.rootObjects(), "qml/Main.qml failed to load:\n  " + "\n  ".join(warnings)

--- a/tests/test_qml_snippets.py
+++ b/tests/test_qml_snippets.py
@@ -55,6 +55,7 @@ except ImportError as exc:  # pragma: no cover - environment-dependent
 
 from src.keyboard_bridge import KeyboardBridge  # noqa: E402
 from src.snippets import MAX_SNIPPETS, SNIPPET_COLORS, SnippetStore  # noqa: E402
+from tests.qml_context import install_context_properties  # noqa: E402
 from tests.qt_settings_scope import TEST_APP, TEST_ORG  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -110,7 +111,7 @@ def snippets_window(qapp, tmp_path):
 
     engine = QQmlApplicationEngine()
     engine.warnings.connect(lambda errs: warnings.extend(e.toString() for e in errs))
-    engine.rootContext().setContextProperty("keyboard", bridge)
+    install_context_properties(engine, bridge)
     engine.load(QUrl.fromLocalFile(str(QML_MAIN)))
 
     assert engine.rootObjects(), "qml/Main.qml failed to load:\n  " + "\n  ".join(warnings)

--- a/tests/test_qml_symbols.py
+++ b/tests/test_qml_symbols.py
@@ -48,6 +48,7 @@ except ImportError as exc:  # pragma: no cover - environment-dependent
 
 from src.glyphs import MAX_RECENT  # noqa: E402
 from src.keyboard_bridge import KeyboardBridge  # noqa: E402
+from tests.qml_context import install_context_properties  # noqa: E402
 from tests.qt_settings_scope import TEST_APP, TEST_ORG  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -108,7 +109,7 @@ def picker_factory(qapp):
 
         engine = QQmlApplicationEngine()
         engine.warnings.connect(lambda errs: warnings.extend(e.toString() for e in errs))
-        engine.rootContext().setContextProperty("keyboard", bridge)
+        install_context_properties(engine, bridge)
         engine.load(QUrl.fromLocalFile(str(QML_MAIN)))
         assert engine.rootObjects(), "qml/Main.qml failed to load:\n  " + "\n  ".join(warnings)
         engines.append(engine)

--- a/tests/test_qml_ui_state_fuzz.py
+++ b/tests/test_qml_ui_state_fuzz.py
@@ -45,6 +45,7 @@ from tests.test_qml_compact_view import (  # noqa: E402
     _pump_until,
     _real_warnings,
     _theme_names,
+    install_context_properties,
 )
 
 # Reuse that module's `qapp` / `qml_root` fixtures without importing their
@@ -649,7 +650,7 @@ class TestRestartPersistence:
 
         engine = QQmlApplicationEngine()
         engine.warnings.connect(lambda errs: warnings.extend(e.toString() for e in errs))
-        engine.rootContext().setContextProperty("keyboard", bridge)
+        install_context_properties(engine, bridge)
         engine.load(QUrl.fromLocalFile(str(_QML_MAIN)))
         assert engine.rootObjects(), "Main.qml failed to reload"
         _settle()

--- a/tests/test_telemetry_bridge.py
+++ b/tests/test_telemetry_bridge.py
@@ -1,0 +1,165 @@
+"""Tests for TelemetryBridge, the QML-facing wrapper around the opt-in
+telemetry pipeline.
+
+This is the first surface pulled off ``KeyboardBridge`` per
+``docs/architecture/STRUCTURAL_REVIEW.md`` section 3.1 -- telemetry
+already delegated everything real to ``TelemetryClient`` (tested
+directly in ``test_telemetry.py``), so what is left to verify here is
+the QObject plumbing: the timer runs, ``shutdown()`` tears it down in
+the right order and never lets a submit failure escape, and the three
+slots delegate rather than reimplement anything.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+from src.telemetry_bridge import TelemetryBridge  # noqa: E402
+
+
+def _stats() -> Dict[str, Any]:
+    """A reasonable lifetime stats dict, matching what the analytics
+    provider callable is expected to return."""
+    return {
+        "alltimeKeystrokes": 1000,
+        "alltimeWords": 200,
+        "alltimePredictionHits": 50,
+        "alltimeKeystrokesSaved": 300,
+        "alltimeMinutes": 25.5,
+        "alltimeSessions": 5,
+        "alltimePredictionOffers": 80,
+    }
+
+
+@pytest.fixture
+def qapp():
+    """A Qt application for the timer machinery under test.
+
+    ``TestTheHourlyTimer`` asserts ``QTimer.isActive()``, and a ``QTimer``
+    started with no ``QCoreApplication`` instance in the process silently
+    fails to arm -- ``start()`` returns, but ``isActive()`` reads back
+    False, which is indistinguishable from a bug in ``TelemetryBridge``
+    unless the timer had a real application to register with.
+
+    **It must be a ``QGuiApplication``, not a ``QCoreApplication``.** This
+    module needs no GUI, but an application cannot be upgraded once
+    created, and under ``-n auto`` this module and the headless QML
+    modules land in the same worker process often enough: creating a core
+    app here would leave any QML test that ran afterwards in the same
+    worker unable to build the ``QGuiApplication`` its engine needs. Same
+    reasoning as the identical fixture in ``test_dictation.py``.
+    """
+    from PySide6.QtCore import QCoreApplication
+    from PySide6.QtGui import QGuiApplication
+
+    from tests.qt_settings_scope import TEST_APP, TEST_ORG
+
+    app = QGuiApplication.instance()
+    if app is None:
+        QCoreApplication.setOrganizationName(TEST_ORG)
+        QCoreApplication.setApplicationName(TEST_APP)
+        app = QGuiApplication([])
+    assert QCoreApplication.organizationName() == TEST_ORG, (
+        "another test created a Qt application under a different "
+        "organisation - QML Settings would write to the real user's store"
+    )
+    return app
+
+
+@pytest.fixture
+def telemetry_bridge(qapp) -> TelemetryBridge:
+    """A TelemetryBridge with a plain analytics-provider stub.
+
+    The bridge builds its own ``TelemetryClient`` internally -- the whole
+    point of the split is that ``TelemetryClient`` stays the source of
+    truth for consent -- so tests that need to control what the client
+    does swap out ``._telemetry``, the same ``bridge._foo`` pattern the
+    rest of this suite uses to reach into a bridge's backing objects.
+    """
+    return TelemetryBridge(_stats, app_version="1.0.16", os_name="windows")
+
+
+class TestTheHourlyTimer:
+    """The QTimer that periodically calls ``TelemetryClient.maybe_submit``."""
+
+    def test_the_timer_is_running_after_construction(
+        self, telemetry_bridge: TelemetryBridge
+    ) -> None:
+        timer = telemetry_bridge._telemetry_timer
+        assert timer.isActive()
+
+    def test_the_interval_is_one_hour(self, telemetry_bridge: TelemetryBridge) -> None:
+        # Hourly tick is plenty: maybe_submit() short-circuits unless the
+        # 7-day window has elapsed, and a no-op call costs ~5 microseconds.
+        assert telemetry_bridge._telemetry_timer.interval() == 60 * 60 * 1000
+
+
+class TestShutdown:
+    """Stops the timer and makes a last-chance on-quit submit."""
+
+    def test_shutdown_stops_the_timer(self, telemetry_bridge: TelemetryBridge) -> None:
+        telemetry_bridge._telemetry = MagicMock()
+        telemetry_bridge.shutdown()
+        assert not telemetry_bridge._telemetry_timer.isActive()
+
+    def test_shutdown_calls_submit_on_quit_once(self, telemetry_bridge: TelemetryBridge) -> None:
+        mock_client = MagicMock()
+        telemetry_bridge._telemetry = mock_client
+        telemetry_bridge.shutdown()
+        mock_client.submit_on_quit.assert_called_once()
+
+    def test_shutdown_swallows_and_logs_a_submit_failure(
+        self, telemetry_bridge: TelemetryBridge, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Internally gated on consent + endpoint + anon_id + a 60 s
+        # anti-spam window, so a real client would rarely raise here --
+        # but the on-quit path must not let *any* exception from it
+        # escape and abort the rest of the app's teardown.
+        mock_client = MagicMock()
+        mock_client.submit_on_quit.side_effect = RuntimeError("simulated network failure")
+        telemetry_bridge._telemetry = mock_client
+
+        with caplog.at_level(logging.INFO, logger="TelemetryBridge"):
+            telemetry_bridge.shutdown()  # must not raise
+
+        assert "telemetry on-quit submit failed" in caplog.text
+        assert "simulated network failure" in caplog.text
+
+
+class TestTheThreeSlots:
+    """getEnabled / setEnabled / forgetData delegate to TelemetryClient."""
+
+    def test_get_enabled_reads_the_client(self, telemetry_bridge: TelemetryBridge) -> None:
+        mock_client = MagicMock()
+        mock_client.enabled = True
+        telemetry_bridge._telemetry = mock_client
+        assert telemetry_bridge.getEnabled() is True
+
+    def test_set_enabled_true_calls_enable(self, telemetry_bridge: TelemetryBridge) -> None:
+        mock_client = MagicMock()
+        telemetry_bridge._telemetry = mock_client
+        telemetry_bridge.setEnabled(True)
+        mock_client.enable.assert_called_once()
+        mock_client.disable.assert_not_called()
+
+    def test_set_enabled_false_calls_disable(self, telemetry_bridge: TelemetryBridge) -> None:
+        mock_client = MagicMock()
+        telemetry_bridge._telemetry = mock_client
+        telemetry_bridge.setEnabled(False)
+        mock_client.disable.assert_called_once()
+        mock_client.enable.assert_not_called()
+
+    def test_forget_data_calls_forget_and_returns_its_result(
+        self, telemetry_bridge: TelemetryBridge
+    ) -> None:
+        mock_client = MagicMock()
+        mock_client.forget.return_value = True
+        telemetry_bridge._telemetry = mock_client
+        assert telemetry_bridge.forgetData() is True
+        mock_client.forget.assert_called_once()


### PR DESCRIPTION
## Summary

- Sequence item 6 of `docs/architecture/STRUCTURAL_REVIEW.md`: split ONE bolt-on feature surface off `KeyboardBridge` and measure what it costs before deciding whether to continue. Telemetry was the candidate: three slots, three QML call sites, one backing `TelemetryClient`.
- New `src/telemetry_bridge.py`: `TelemetryBridge(QObject)` owns the client and the hourly submit timer (moved verbatim) and exposes `getEnabled` / `setEnabled` / `forgetData` plus a `shutdown()` that stops the timer and does the guarded on-quit submit. It is registered as the `telemetry` QML context property beside `keyboard`, parented to the bridge so its lifetime is tied to a live Qt owner. `KeyboardBridge` no longer references telemetry at all (net -46 lines); the only seam it needed was a read-only `analytics` property.
- QML: the three calls in `UnifiedSettingsPanel.qml` become `telemetry.getEnabled()`, `telemetry.setEnabled(c)`, `telemetry.forgetData()`.
- Tests: `tests/qml_context.py::install_context_properties` now registers both context properties, replacing seven hand-rolled `setContextProperty("keyboard", ...)` calls across the headless QML fixtures, so the next context property is one edit rather than eight. `tests/test_telemetry_bridge.py` covers the timer, the slots delegating, and `shutdown()` stopping the timer, submitting once, and swallowing a submit failure.

## The measurement

- Bridge: 56 lines removed, 10 added. One seam (the `analytics` property). Shutdown order preserved by calling `telemetry.shutdown()` immediately before `bridge.shutdown()` in `_on_about_to_quit`.
- The move itself was mechanical and cheap. The real cost was elsewhere: keeping seven scattered QML fixtures registering context properties in step (solved once with the helper), and a Qt lifecycle flake in the new test module (`QTimer.isActive()` reads False with no `QCoreApplication` in that xdist worker) that needed the module-level `qapp` fixture pattern `test_dictation.py` already uses.
- `rg -c 'bridge\._' tests/` went from 841 to 852; all eleven new hits are `telemetry_bridge._telemetry` in the new test file, so the number is not a clean coupling signal without that caveat. No bridge test referenced telemetry before, so nothing had to move.
- Prediction for the next surface: data export is a different bet. Six slots instead of three, and `importUserData` calls `reload_from_disk()` on the predictor, analytics and snippets store and clears the bridge's typing buffers, which is real behavioural coupling to bridge state rather than pass-through delegation. Expect the one seam here to become three or four there; the QML and fixture mechanics are the same in kind.

## Related issue

No issue; follows the structural review recorded in #53.

## Type of change

- [x] Refactor (no behavior change)

## Test plan

- [x] `python check.py` passes locally (ruff, format, mypy linux + win32, pytest: 1880 passed, 3 skipped)
- [x] New `tests/test_telemetry_bridge.py` (9 tests); the six headless QML suites pass unchanged through the shared helper; `tests/test_telemetry.py` (the client) untouched.

## Accessibility check

n/a.

## Notes for reviewers

- `TelemetryClient` stays the source of truth for the consent flag; nothing is mirrored into `appSettings`. `docs/architecture/TELEMETRY.md` and CLAUDE.md name the new slot names and the `telemetry` context property.
- This is the "measurement, not a commitment" item: merging it does not imply splitting data export next. The numbers above are what that decision should be made on.
