### PR TITLE
chore: give the suite jobs a twenty-minute timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,12 @@ jobs:
   test:
     name: Test (${{ matrix.os }} ${{ matrix.shard }}/4)
     runs-on: ${{ matrix.os }}
+    # A shard finishes in about six minutes, so one that reaches twenty has
+    # hung, not slowed. Without this the default is six hours: on 2026-09-03
+    # a windows shard reached 84% in four minutes and then produced nothing
+    # for twenty-eight more, holding its PR until someone cancelled it by
+    # hand. The rerun passed in six.
+    timeout-minutes: 20
     permissions:
       contents: read
     strategy:
@@ -229,6 +235,9 @@ jobs:
     name: Coverage (${{ matrix.os }})
     needs: test
     runs-on: ${{ matrix.os }}
+    # Same reasoning as the test job: this runs the whole suite on one
+    # machine and can hang the same way.
+    timeout-minutes: 20
     permissions:
       contents: read
     strategy:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -728,6 +728,11 @@ each one fixed: `docs/build/CI.md`. The rules that outlive the reasoning:
   setup rather than test count. If the gate creeps back up, measure before
   tiering: coverage on the one gate that runs before code leaves the machine
   is the last thing to trade away.
+- **The `test` and `coverage` jobs carry `timeout-minutes: 20`.** A shard
+  finishes in about six minutes, so a job that reaches twenty has hung, not
+  slowed; without it the default is six hours, and a flaky hang on a windows
+  shard held a PR for half an hour until it was cancelled by hand. If the
+  shards ever grow toward it, measure what grew before raising the number.
 
 **A test module that constructs a Qt application must build a
 `QGuiApplication` under that same scope, never a bare

--- a/docs/build/CI.md
+++ b/docs/build/CI.md
@@ -107,6 +107,21 @@ The default cancelled every sibling on the first red, so one flaky ubuntu
 test took the windows job down with it and the run reported two failures
 where there was one, with nothing to say whether windows would have passed.
 
+## The suite jobs carry `timeout-minutes: 20`
+
+GitHub's default job timeout is six hours. On 2026-09-03 a windows shard on
+PR #66 reached 84% in four minutes and then produced nothing for
+twenty-eight more; with xdist's `-q` output there was no name to go on, the
+same shard had passed on the three sibling PRs whose test sets were
+supersets of it, and the rerun passed in six minutes. So it was a flaky
+hang, and the cost of a flaky hang is set by the timeout: without one it
+holds the PR until somebody notices and cancels by hand.
+
+Twenty minutes is about three times the slowest shard observed and applies
+to the `test` and `coverage` jobs, the two that run pytest. A job that
+reaches it has hung, not slowed, so if the shards ever grow toward it the
+answer is to measure what grew, not to raise the number first.
+
 ## Branch protection requires the `Tests` job, not the shards
 
 Required status checks are configured by *name*, in the repo settings


### PR DESCRIPTION
## Summary

- Adds `timeout-minutes: 20` to the `test` and `coverage` jobs, the two that run pytest. GitHub's default is six hours.
- Records the reasoning in `docs/build/CI.md` and as a rule in `CLAUDE.md`'s pre-push section, next to the other CI choices that outlive their reasoning.

## Related issue

No issue. Follows from a hung windows shard on #66 today: the shard reached 84% in four minutes, then produced nothing for twenty-eight more until it was cancelled by hand (https://github.com/owenpkent/alpha-osk/actions/runs/33795837543/job/100783284725). The same shard had passed on the three sibling PRs whose test sets were supersets of it, and the rerun passed in six minutes, so it was a flaky hang. The timeout sets what a flaky hang costs.

## Type of change

- [x] Build / CI / tooling

## Test plan

- [x] `python check.py` passes locally (no Python changed; the pre-push hook ran it anyway)
- [ ] Added or updated tests: n/a, workflow configuration
- CI on this PR is the test: every shard and both coverage jobs should finish well inside the limit. The slowest shard observed today took about six minutes.

## Accessibility check

n/a, no runtime change.

## Notes for reviewers

**Touches the CI pipeline**, called out per `CLAUDE.md`. Twenty minutes is about three times the slowest shard observed, so a job that reaches it has hung rather than slowed. If the shards ever grow toward it, the answer is to measure what grew, not to raise the number first; the doc says so.
