### PR TITLE
feat: give the title bar a right-click window menu with a click-free Move

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1504,6 +1504,85 @@ are in *Key rules* at the top of this file.
 - **`pressKey` lowercases its input** - use `pressKeyLiteral` when QML already resolved the final character (right-click shifted variant, etc.).
 - **QML `Text` defaults to `AutoText`, which sniffs the string for HTML and can trigger an outbound request just from being displayed.** Any `Text` rendering a value that ultimately came from imported or otherwise untrusted data (a vocabulary pack's `name`/`description`, anything read from a file the user picked) must set `textFormat: Text.PlainText` explicitly, or an `<img src=...>` planted in that string makes Qt fetch it the moment the Settings page renders. 23 `Text` elements across 7 QML files (`Main.qml`, `UnifiedSettingsPanel.qml`, `DebugPanel.qml`, `AnalyticsDashboard.qml`, `ModelVisualization.qml`, `KeyButton.qml`, `SettingsToggle.qml`) now set it explicitly; new `Text` elements displaying untrusted strings must too. **Known gap**: the attached-property `ToolTip.text` idiom has no `textFormat` to set, so a tooltip built from untrusted text is not covered.
 
+## Title-bar window menu, and click-free Move
+
+Right-clicking the title bar opens the menu a real window's caption strip
+gives you: **Move**, **Minimize**, **Tuck away / Bring back** (X11 only),
+**Close**. The keyboard is frameless and `WS_EX_NOACTIVATE`, so it has no OS
+system menu and no gesture that reaches one (Alt+Space wants the focus we
+deliberately never take). Everything lives in `qml/Main.qml`; guarded by
+`tests/test_qml_window_menu.py`.
+
+Three of the four entries also have a caption button a few pixels away, and
+that is the point rather than a redundancy: those are 28x24 targets bunched at
+the far right end of the bar, and the menu puts the same actions under the
+pointer wherever it already is on the strip the user grabs the window by.
+
+- **`titleBarMenuArea` is declared *before* every other child of `titleBar`
+  and accepts only `Qt.RightButton`.** Being first puts it underneath
+  everything, and taking only the right button means it consumes nothing else:
+  a left press still reaches `dragArea` and the caption buttons above it,
+  while a right press finds no taker up there and falls through. That is what
+  makes the *whole* strip a menu target, buttons and the gaps between them
+  included, rather than only the region `dragArea` covers (which stops 332 px
+  short of the right edge). The failure mode to avoid is declaring it on top:
+  it would silently kill dragging the window. `dragArea` shields it well
+  enough that "a left press does not open the menu" is not a falsifiable test,
+  so the guard is
+  `TestRightClickingTheTitleBarOpensTheMenu::test_a_left_drag_on_the_strip_still_moves_the_window`,
+  which presses, travels and asserts the window followed.
+- **Rows come from a model (`windowMenu.actions`), not four near-identical
+  blocks**, and are **word-only, no icons**: any glyph small enough to sit in a
+  menu row is at the mercy of the host emoji font, which on Windows renders in
+  colour and ignores the ink it is given (same reason as the lock badge and the
+  clear-context ring). The Tuck row is built unconditionally and **collapses to
+  zero height** off X11, because a row for something that cannot happen is
+  worse than no row. **Close carries a rule and a 9 px gap above it**: it is
+  the one row that ends the session, there is no undo, and it must not sit
+  flush against Minimize under an imprecise pointer.
+
+### Move mode
+
+**The one entry with no button behind it, and the reason the menu is worth
+having.** Dragging the title bar means holding the button down for the whole
+travel, which is the single gesture this keyboard's user cannot reliably make
+(the same argument that removed swipe typing). Move mode splits it into two
+taps with a free hand in between: pick the window up, move it, put it down.
+
+- **The window follows the pointer by `(current - anchor)` in the overlay's own
+  coordinates, and that is self-correcting**: the window slides out from under
+  the pointer by exactly the delta, which puts the pointer back on the anchor
+  and makes the next delta zero. It converges instead of running away, and it
+  needs no global coordinates. A sub-pixel delta is left to accumulate rather
+  than rounded away, or the same delta stays pending on every later event.
+- **The anchor is dropped on `onExited` as well as on open.** A fast flick can
+  outrun the window it is dragging; measuring the way back in against the
+  anchor the excursion started from teleports the window by however far the
+  pointer went while it was away.
+- **`windowMoveOverlay` covers the whole window and is `enabled: root.moveMode`,
+  not merely hidden.** It has to swallow the click that ends the move, or that
+  click lands on a key, a pill or the Close button.
+- **Left puts it down, right puts it back** (`_moveReturnX/Y`). There is no
+  Escape: this window never holds focus, so a physical Escape goes to the app
+  behind us and the OSK's own Esc key is synthesised into that app too. The
+  cancel is what makes the mode safe to try for someone who could not recover
+  a window that landed somewhere unreachable, so don't drop it.
+- A hint banner rides on the overlay saying which click does which. It is not
+  garnish: a keyboard that has started following the pointer with nothing on
+  screen to say why is alarming, and the mode has no other tell.
+- The landing spot persists for free, since `onXChanged` / `onYChanged` already
+  restart `saveGeometryTimer`.
+
+**Testing note.** `tests/test_qml_window_menu.py` drives the pointer in
+*desktop* coordinates, not window-local ones. In move mode the two are not
+interchangeable: the window slides by exactly the delta, so the same local
+point maps back to the same global point and Qt drops the second event as a
+duplicate. Two other offscreen-plugin traps are pinned in that file: a window
+parked at a negative x is reported 4 px adrift of where it was put (hence
+`PARKED_X`/`PARKED_Y`), and a closed `Popup`'s rows all report
+`visible: false`, so any assertion about which rows are showing has to open the
+menu first or it passes against anything at all.
+
 ## Right-Click for Shifted Character
 
 Right-click on a char key types its shifted variant without flipping the sticky shift state - `1` -> `!`, `,` -> `<`, `a` -> `A`. Modifier and special keys are deliberate no-ops. Toggle in *Settings -> Smart Typing -> Input -> "Right-Click for Shifted Character"* (default ON; left-click is unaffected whether on or off). Implementation:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1518,8 +1518,10 @@ that is the point rather than a redundancy: those are 28x24 targets bunched at
 the far right end of the bar, and the menu puts the same actions under the
 pointer wherever it already is on the strip the user grabs the window by.
 
-- **`titleBarMenuArea` is declared *before* every other child of `titleBar`
-  and accepts only `Qt.RightButton`.** Being first puts it underneath
+- **`titleBarMenuArea` is declared *before* every other input-taking child of
+  `titleBar` and accepts only `Qt.RightButton`.** Only the corner-rounding
+  Rectangle sits above it in the file, and that accepts nothing. Being first
+  puts it underneath
   everything, and taking only the right button means it consumes nothing else:
   a left press still reaches `dragArea` and the caption buttons above it,
   while a right press finds no taker up there and falls through. That is what

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -175,6 +175,35 @@ Window {
         }
     }
 
+    // Click-free window move, offered as "Move" on the title bar's right-click
+    // menu.  Dragging the bar means holding the button down for the whole
+    // travel, and a sustained precise hold is the one gesture this keyboard's
+    // user cannot reliably make -- the same argument that removed swipe
+    // typing.  Move mode splits the drag into two taps with a free hand in
+    // between: pick the window up, move it, put it down.  `_moveReturnX/Y` is
+    // where a cancel puts it back, which is what makes the mode safe to try.
+    property bool moveMode: false
+    property real _moveReturnX: 0
+    property real _moveReturnY: 0
+
+    function beginWindowMove() {
+        if (root.moveMode) return
+        root._moveReturnX = root.x
+        root._moveReturnY = root.y
+        root.moveMode = true
+    }
+
+    function endWindowMove(cancelled) {
+        if (!root.moveMode) return
+        root.moveMode = false
+        if (cancelled) {
+            root.x = root._moveReturnX
+            root.y = root._moveReturnY
+        }
+        // No explicit save: onXChanged / onYChanged already restart
+        // saveGeometryTimer, so the landing spot persists like any drag.
+    }
+
     // Safety net: if the keyboard was parked off-screen (DOCK) and then put
     // away and brought back via the tray, restore it to a usable on-screen
     // NORMAL state instead of reappearing off-screen. Tuck's own move doesn't
@@ -1065,6 +1094,27 @@ Window {
                 color: parent.color
             }
             
+            // Right-click anywhere on the bar opens the window menu.
+            //
+            // Declared *before* every other child so it sits underneath them
+            // all, and accepting only the right button so it consumes nothing
+            // else: a left press still reaches dragArea and the caption
+            // buttons on top of it, while a right press finds no taker up
+            // there and falls through to here.  That is what makes the whole
+            // strip a menu target -- the grip, the gaps between the buttons,
+            // and the buttons themselves -- the way a real caption bar is,
+            // rather than only the drag region dragArea happens to cover
+            // (which stops 332 px short of the right edge).
+            MouseArea {
+                id: titleBarMenuArea
+                anchors.fill: parent
+                acceptedButtons: Qt.RightButton
+                onPressed: function (mouse) {
+                    var pos = mapToItem(background, mouse.x, mouse.y)
+                    windowMenu.showAt(pos.x, pos.y)
+                }
+            }
+
             // Drag area (most of title bar)
             MouseArea {
                 id: dragArea
@@ -2769,6 +2819,245 @@ Window {
                 repeatDelay: root.repeatDelay
                 repeatInterval: root.repeatInterval
             }
+            }
+        }
+
+        // ===== Move mode =====
+        // While active the window follows the pointer with no button held,
+        // and a click puts it down.  It covers the whole window so the
+        // pointer cannot fall off the thing it is dragging, and so no key,
+        // pill or caption button can be hit by the click that ends the move.
+        MouseArea {
+            id: windowMoveOverlay
+            anchors.fill: parent
+            z: 200
+            visible: root.moveMode
+            enabled: root.moveMode
+            hoverEnabled: true
+            cursorShape: Qt.SizeAllCursor
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+
+            // The pointer's position within this overlay when the follow
+            // began.  Moving the window by (current - anchor) is
+            // self-correcting: the window slides out from under the pointer
+            // by exactly that much, which puts the pointer back on the anchor
+            // and makes the next delta zero.  So it converges instead of
+            // running away, and it needs no global coordinates.
+            property bool anchored: false
+            property real anchorX: 0
+            property real anchorY: 0
+
+            // Re-anchor rather than resume, both when the mode opens and if a
+            // fast flick outruns the window and the pointer leaves it.  The
+            // alternative is measuring against a stale anchor on the way back
+            // in, which teleports the window by however far the excursion went.
+            // Qt fires onExited when an item under the pointer is hidden, so
+            // that one covers the close of a mode as well; onVisibleChanged is
+            // what keeps "a mode opens unanchored" from resting on that.
+            onVisibleChanged: anchored = false
+            onExited: anchored = false
+
+            onPositionChanged: function (mouse) {
+                if (!anchored) {
+                    anchorX = mouse.x
+                    anchorY = mouse.y
+                    anchored = true
+                    return
+                }
+                var dx = mouse.x - anchorX
+                var dy = mouse.y - anchorY
+                // Window positions are whole pixels, so a sub-pixel delta
+                // would round away to no move at all and leave the same
+                // delta pending on every later event.  Let it accumulate.
+                if (Math.abs(dx) < 1 && Math.abs(dy) < 1) return
+                root.x = Math.round(root.x + dx)
+                root.y = Math.round(root.y + dy)
+            }
+
+            // Left puts it down, right puts it back.  Escape is not an option
+            // here the way it is in a real window's move mode: this window
+            // never holds focus, so a physical Escape goes to the app behind
+            // us and the OSK's own Esc key is synthesised into that app too.
+            onPressed: function (mouse) {
+                root.endWindowMove(mouse.button === Qt.RightButton)
+            }
+
+            // The mode has no other tell, and a keyboard that has started
+            // following the pointer with nothing on screen to say why is
+            // alarming.  Parked at the top, clear of where the pointer is.
+            Rectangle {
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.top: parent.top
+                anchors.topMargin: 12
+                width: moveHintText.implicitWidth + 28
+                height: 34
+                radius: 17
+                color: root.themeAccent
+                border.color: Qt.rgba(0, 0, 0, 0.35)
+                border.width: 1
+
+                Text {
+                    id: moveHintText
+                    anchors.centerIn: parent
+                    text: qsTr("Click to place the keyboard \u00B7 right-click to cancel")
+                    textFormat: Text.PlainText
+                    font.pixelSize: 13
+                    font.bold: true
+                    color: root.inkOn(root.themeAccent)
+                }
+            }
+        }
+
+        // ===== Title-bar window menu =====
+        // The menu a real window's caption strip gives you on a right-click.
+        // This one is frameless and WS_EX_NOACTIVATE, so it has no OS system
+        // menu and no way to reach one -- Alt+Space wants the focus we
+        // deliberately never take.  Minimize, Tuck and Close each also have a
+        // caption button a few pixels away, and that is the point rather than
+        // a redundancy: those are 28x24 targets bunched at the far right end,
+        // and this puts them under the pointer wherever it already is on the
+        // strip.  Move is the one entry with no button behind it.
+        Popup {
+            id: windowMenu
+
+            parent: Overlay.overlay
+            property real popupX: 0
+            property real popupY: 0
+            x: popupX
+            y: popupY
+            width: 216
+            height: windowMenuCol.implicitHeight
+            padding: 0
+            modal: true
+            dim: false
+            closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+            // One destructive colour, picked per theme rather than fixed, the
+            // same rule the snippets window uses: a dark red is illegible on
+            // Typewriter's cream and a bright one glares on Spaceship.
+            readonly property color danger: root.luminance(root.themeBackground) > 0.5
+                                            ? "#a3271c" : "#ef8b80"
+
+            // One row per action, as a model rather than four near-identical
+            // blocks -- they differ only in their label and in what they call,
+            // and parallel copies of one shape is how this codebase's bugs
+            // start.  Word-only, no icons: every glyph small enough to sit in
+            // a menu row is at the mercy of the host emoji font, which on
+            // Windows renders in colour and ignores the ink it is given (see
+            // the lock badge and the clear-context ring).
+            readonly property var actions: [
+                { action: "move", label: qsTr("Move"), gapAbove: false, destructive: false },
+                { action: "minimize", label: qsTr("Minimize"), gapAbove: false, destructive: false },
+                { action: "tuck",
+                  label: root.tucked ? qsTr("Bring back") : qsTr("Tuck away"),
+                  gapAbove: false, destructive: false },
+                { action: "close", label: qsTr("Close"), gapAbove: true, destructive: true }
+            ]
+
+            function showAt(localX, localY) {
+                popupX = Math.max(4, Math.min(localX, root.width - width - 4))
+                popupY = Math.max(4, Math.min(localY + 4, root.height - height - 4))
+                open()
+            }
+
+            function invoke(action) {
+                close()
+                if (action === "move") root.beginWindowMove()
+                else if (action === "minimize") root.showMinimized()
+                else if (action === "tuck") root.toggleTuck()
+                else if (action === "close") Qt.quit()
+            }
+
+            // The theme's key colour, which is what a raised surface is made of
+            // everywhere else here (the snippets window calls it `surface`).
+            // Deriving it from the window background instead reads as a hole
+            // rather than a panel: on the dark themes that background is
+            // already near-black, so a darkened copy of it is separated from
+            // the app only by the border, and on Typewriter's cream the same
+            // expression has to go the other way to work at all.  The key
+            // colour is the one surface every theme already guarantees
+            // `themeTextColor` is legible on.
+            background: Rectangle {
+                color: root.themeKeyColor
+                border.color: root.themeBorder
+                border.width: 1
+                radius: 10
+            }
+
+            contentItem: Column {
+                id: windowMenuCol
+                width: windowMenu.width
+                padding: 6
+                spacing: 2
+
+                Repeater {
+                    model: windowMenu.actions
+
+                    delegate: Item {
+                        id: menuRow
+                        // The row's own label, republished as a property
+                        // because the tests cannot reach it any other way: a
+                        // Repeater's delegates are re-parented as *visual*
+                        // children, so findChildren() returns none of them.
+                        readonly property string rowLabel: modelData.label
+                        // Tuck is X11-only, and a row for a thing that cannot
+                        // happen is worse than no row: it collapses to nothing
+                        // rather than sitting there inert.
+                        readonly property bool shown: modelData.action !== "tuck"
+                                                      || root.tuckSupported
+                        // 40 px, not the 34 the pill menu uses: this is a
+                        // menu one of whose rows quits the application.
+                        readonly property real gap: modelData.gapAbove ? 9 : 0
+                        width: windowMenuCol.width - 12
+                        height: shown ? 40 + gap : 0
+                        visible: shown
+
+                        // Close sits under a rule and a gap, so the row that
+                        // ends the session is not flush against the one above
+                        // it under an imprecise pointer.
+                        Rectangle {
+                            anchors.top: parent.top
+                            anchors.topMargin: 4
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            width: parent.width - 16
+                            height: 1
+                            visible: modelData.gapAbove
+                            color: Qt.rgba(root.themeTextColor.r, root.themeTextColor.g,
+                                           root.themeTextColor.b, 0.18)
+                        }
+
+                        Rectangle {
+                            id: rowFill
+                            anchors.bottom: parent.bottom
+                            width: parent.width
+                            height: 40
+                            radius: 7
+                            readonly property color hoverFill: modelData.destructive
+                                                               ? windowMenu.danger
+                                                               : root.themeAccent
+                            color: rowMa.containsMouse ? hoverFill : "transparent"
+
+                            Text {
+                                anchors.verticalCenter: parent.verticalCenter
+                                anchors.left: parent.left
+                                anchors.leftMargin: 14
+                                text: modelData.label
+                                textFormat: Text.PlainText
+                                font.pixelSize: 14
+                                color: rowMa.containsMouse ? root.inkOn(rowFill.hoverFill)
+                                                           : root.themeTextColor
+                            }
+
+                            MouseArea {
+                                id: rowMa
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: windowMenu.invoke(modelData.action)
+                            }
+                        }
+                    }
+                }
             }
         }
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -1096,8 +1096,10 @@ Window {
             
             // Right-click anywhere on the bar opens the window menu.
             //
-            // Declared *before* every other child so it sits underneath them
-            // all, and accepting only the right button so it consumes nothing
+            // Declared *before* every other child that takes input, so it
+            // sits underneath them all (only the corner-rounding Rectangle
+            // is above it, and that accepts nothing), and accepting only the
+            // right button so it consumes nothing
             // else: a left press still reaches dragArea and the caption
             // buttons on top of it, while a right press finds no taker up
             // there and falls through to here.  That is what makes the whole

--- a/tests/test_qml_window_menu.py
+++ b/tests/test_qml_window_menu.py
@@ -1,0 +1,478 @@
+"""Headless QML tests for the title bar's right-click window menu.
+
+The whole feature is QML -- the right-button MouseArea under the caption
+strip, the menu popup, and the click-free move mode -- so the Python suite
+cannot reach any of it.  These load the real `qml/Main.qml` under the
+`offscreen` platform plugin and drive real `QTest` mouse events at it.
+
+Driving real events rather than the QML API is the point.  The menu has to
+open on a right press *without* taking the left press the drag needs, and a
+version that got that backwards would pass every test that only called
+`showAt()` directly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+# Must be set before QGuiApplication is constructed.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+# See the note in tests/test_qml_compact_view.py: QtGui dlopens the host's
+# libEGL / libGL at module scope, and an ImportError there is a *collection*
+# error that aborts the whole run rather than failing this one module.
+try:
+    from PySide6.QtCore import QCoreApplication, QPoint, QSettings, Qt, QUrl  # noqa: E402
+    from PySide6.QtGui import QGuiApplication  # noqa: E402
+    from PySide6.QtQml import QQmlApplicationEngine, QQmlEngine, QQmlExpression  # noqa: E402
+    from PySide6.QtQuick import QQuickItem  # noqa: E402,F401
+    from PySide6.QtTest import QTest  # noqa: E402
+except ImportError as exc:  # pragma: no cover - environment-dependent
+    pytest.skip(
+        f"Qt GUI libraries unavailable ({exc}); install libegl1/libgl1 to run "
+        "the headless QML tests",
+        allow_module_level=True,
+    )
+
+from src.keyboard_bridge import KeyboardBridge  # noqa: E402
+from tests.qml_context import install_context_properties  # noqa: E402
+from tests.qt_settings_scope import TEST_APP, TEST_ORG  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+QML_MAIN = REPO_ROOT / "qml" / "Main.qml"
+
+IGNORED_WARNING_FRAGMENTS = ("does not support customization",)
+
+# The title bar is 48 px tall, and dragArea leaves the right-hand 332 px of it
+# to the caption buttons.  That split is exactly what the menu has to straddle.
+TITLE_BAR_HEIGHT = 48
+CAPTION_BUTTON_RESERVE = 332
+
+# Somewhere with both coordinates comfortably positive.  The saved-geometry
+# restore lands the window at a negative x under the offscreen plugin, and a
+# negative origin makes that plugin report a window position 4 px adrift of
+# where it was actually put -- so a move of 45 px measures as 49.  Nothing to
+# do with this feature (y, which stays positive, is exact throughout), but it
+# would make every displacement assertion below wrong by a constant.
+PARKED_X = 200
+PARKED_Y = 100
+
+
+def _real_warnings(warnings: list[str]) -> list[str]:
+    return [w for w in warnings if not any(frag in w for frag in IGNORED_WARNING_FRAGMENTS)]
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QGuiApplication.instance()
+    if app is None:
+        # A distinct org/app name keeps the QML `Settings` element off the
+        # real user's registry section.
+        QCoreApplication.setOrganizationName(TEST_ORG)
+        QCoreApplication.setApplicationName(TEST_APP)
+        app = QGuiApplication([])
+    assert QCoreApplication.organizationName() == TEST_ORG, (
+        "another test already created a QGuiApplication under a different "
+        "organisation -- these tests would write to the real user's settings"
+    )
+    return app
+
+
+@pytest.fixture
+def qml_root(qapp):
+    """Load Main.qml with a mocked-synth bridge, from clean settings."""
+    warnings: list[str] = []
+    QSettings(TEST_ORG, TEST_APP).clear()
+
+    # Disarm the startup update check -- otherwise every test that lives
+    # three seconds fires a real HTTPS request from a daemon thread that
+    # then emits back into a bridge this fixture has already torn down.
+    settings = QSettings(TEST_ORG, TEST_APP)
+    settings.setValue("ui/savedAutoCheckUpdates", False)
+    settings.sync()
+
+    with patch("src.keyboard_bridge.create_key_synthesizer") as factory:
+        synth = MagicMock()
+        synth.is_available.return_value = True
+        synth.backend_name.return_value = "MockSynth"
+        factory.return_value = synth
+        bridge = KeyboardBridge()
+
+    engine = QQmlApplicationEngine()
+    engine.warnings.connect(lambda errs: warnings.extend(e.toString() for e in errs))
+    install_context_properties(engine, bridge)
+    engine.load(QUrl.fromLocalFile(str(QML_MAIN)))
+
+    assert engine.rootObjects(), "qml/Main.qml failed to load:\n  " + "\n  ".join(warnings)
+    root = engine.rootObjects()[0]
+    qapp.processEvents()
+    yield root, warnings
+    del engine
+
+
+def _eval(root, expression: str):
+    """Evaluate a QML expression in the root object's own scope.
+
+    Everything this feature adds is addressed by `id`, and an id is visible
+    only from inside the component that declares it, so there is no
+    object-tree walk that reaches `windowMenu` or `windowMoveOverlay`.
+    """
+    expr = QQmlExpression(QQmlEngine.contextForObject(root), root, expression)
+    # PySide hands back (value, wasUndefined).  Only the value is interesting;
+    # an undefined read arrives as None and fails the caller's assertion.
+    value, _undefined = expr.evaluate()
+    assert not expr.hasError(), f"{expression}: {expr.error().toString()}"
+    return value
+
+
+def _open_menu(root) -> None:
+    """Open the menu and let it settle.
+
+    The rows have to be read with it open: a closed Popup's contentItem is
+    hidden, so every row reports `visible: false` and an assertion about
+    which ones are showing passes against anything at all.
+    """
+    _eval(root, "windowMenu.open()")
+    QGuiApplication.processEvents()
+    assert _eval(root, "windowMenu.visible")
+
+
+def _menu_rows(root) -> list[tuple[str, bool]]:
+    """(label, visible) for every row the menu built, in order.
+
+    Goes through `Array.prototype`: `children` is a QML list, not a JS array,
+    so calling `.filter` on it directly yields nothing rather than raising --
+    which reads like an empty menu.
+    """
+    raw = _eval(
+        root,
+        "JSON.stringify(Array.prototype.map.call("
+        "  Array.prototype.filter.call(windowMenuCol.children,"
+        "    function (c) { return c.rowLabel !== undefined }),"
+        "  function (c) { return [c.rowLabel, c.visible] }))",
+    )
+    rows = [(label, visible) for label, visible in json.loads(raw)]
+    assert rows, "no menu rows found -- the delegate walk is measuring nothing"
+    return rows
+
+
+def _press(root, x: int, y: int, button) -> None:
+    QTest.mousePress(root, button, Qt.KeyboardModifier.NoModifier, QPoint(x, y))
+    QTest.mouseRelease(root, button, Qt.KeyboardModifier.NoModifier, QPoint(x, y))
+    QGuiApplication.processEvents()
+
+
+def _park(root) -> None:
+    """Put the window somewhere the offscreen plugin reports honestly."""
+    _eval(root, f"root.x = {PARKED_X}; root.y = {PARKED_Y}")
+    QGuiApplication.processEvents()
+
+
+def _pos(root) -> tuple[int, int]:
+    return root.property("x"), root.property("y")
+
+
+def _hover(root, gx: int, gy: int) -> None:
+    """Hover-move the pointer to the *desktop* point (gx, gy).
+
+    Global rather than window-local, because in move mode the two are not
+    interchangeable: the window slides out from under the pointer by exactly
+    the delta, so the same local point maps back to the same global point and
+    Qt drops the second event as a duplicate of the first.  Driving the
+    pointer where it actually is keeps every event distinct, and makes the
+    assertion the honest one anyway -- the window is supposed to follow the
+    pointer across the desktop, not across itself.
+    """
+    QTest.mouseMove(root, QPoint(gx - root.property("x"), gy - root.property("y")))
+    QGuiApplication.processEvents()
+
+
+def _press(root, gx: int, gy: int, button) -> None:
+    local = QPoint(gx - root.property("x"), gy - root.property("y"))
+    QTest.mousePress(root, button, Qt.KeyboardModifier.NoModifier, local)
+    QGuiApplication.processEvents()
+
+
+def _click(root, gx: int, gy: int, button) -> None:
+    local = QPoint(gx - root.property("x"), gy - root.property("y"))
+    QTest.mousePress(root, button, Qt.KeyboardModifier.NoModifier, local)
+    QTest.mouseRelease(root, button, Qt.KeyboardModifier.NoModifier, local)
+    QGuiApplication.processEvents()
+
+
+def _park(root) -> None:
+    """Put the window somewhere the offscreen plugin reports honestly."""
+    _eval(root, f"root.x = {PARKED_X}; root.y = {PARKED_Y}")
+    QGuiApplication.processEvents()
+
+
+def _pos(root) -> tuple[int, int]:
+    return root.property("x"), root.property("y")
+
+
+# Where the move-mode tests settle the pointer before measuring anything.
+# Comfortably inside a parked 1160x406 window.
+ANCHOR_GX, ANCHOR_GY = 600, 350
+
+
+def _begin_move(root) -> tuple[int, int]:
+    """Enter move mode with the anchor settled under the pointer at
+    (ANCHOR_GX, ANCHOR_GY), and report where the window ended up.
+
+    Two hovers, and both are needed.  Qt drops a move to the point the
+    pointer already occupies, and the pointer is process-global while the
+    window is rebuilt for every test, so a lone hover can inherit the
+    previous test's final position and never be delivered -- which leaves the
+    anchor wherever the platform's own opening hover put it, and the
+    measurement that follows wrong by that much.  Two distinct points
+    guarantee one lands.  The baseline is read afterwards, so whatever the
+    settling itself moved is already accounted for.
+    """
+    _park(root)
+    _eval(root, "root.beginWindowMove()")
+    _hover(root, ANCHOR_GX + 60, ANCHOR_GY + 40)
+    _hover(root, ANCHOR_GX, ANCHOR_GY)
+    assert _eval(root, "windowMoveOverlay.anchored")
+    return _pos(root)
+
+
+class TestRightClickingTheTitleBarOpensTheMenu:
+    """The gesture itself, and the left press it must not steal."""
+
+    def test_a_right_press_on_the_drag_strip_opens_it(self, qml_root):
+        root, warnings = qml_root
+        assert not _eval(root, "windowMenu.visible")
+
+        _click(
+            root,
+            root.property("x") + 160,
+            root.property("y") + TITLE_BAR_HEIGHT // 2,
+            Qt.MouseButton.RightButton,
+        )
+
+        assert _eval(root, "windowMenu.visible")
+        assert _real_warnings(warnings) == []
+
+    def test_a_right_press_over_the_caption_buttons_opens_it_too(self, qml_root):
+        """The whole strip is a menu target, the way a real caption bar is.
+
+        dragArea stops 332 px short of the right edge to leave the buttons
+        alone, so a menu wired to *it* would be dead over the half of the bar
+        the buttons occupy, including the gaps between them.
+        """
+        root, warnings = qml_root
+        width = root.property("width")
+        offset = width - 40
+        assert offset > width - CAPTION_BUTTON_RESERVE, "the point must be inside the button strip"
+
+        _click(
+            root,
+            root.property("x") + offset,
+            root.property("y") + TITLE_BAR_HEIGHT // 2,
+            Qt.MouseButton.RightButton,
+        )
+
+        assert _eval(root, "windowMenu.visible")
+        assert _real_warnings(warnings) == []
+
+    def test_a_left_drag_on_the_strip_still_moves_the_window(self, qml_root):
+        """The inverse half, and it has to be the drag rather than the menu.
+
+        Asserting only that a left press does not open the menu proves
+        nothing: dragArea sits on top of the menu's MouseArea and would take
+        that press whether or not the one underneath wanted it.  What the
+        declaration order buys is that dragging still works, so that is what
+        this measures -- press, travel, release, and the window followed.
+        """
+        root, _ = qml_root
+        _park(root)
+        before = _pos(root)
+        grab = (before[0] + 160, before[1] + TITLE_BAR_HEIGHT // 2)
+
+        QTest.mousePress(
+            root,
+            Qt.MouseButton.LeftButton,
+            Qt.KeyboardModifier.NoModifier,
+            QPoint(160, TITLE_BAR_HEIGHT // 2),
+        )
+        _hover(root, grab[0] + 60, grab[1] + 35)
+        moved = _pos(root)
+        QTest.mouseRelease(
+            root,
+            Qt.MouseButton.LeftButton,
+            Qt.KeyboardModifier.NoModifier,
+            QPoint(grab[0] + 60 - moved[0], grab[1] + 35 - moved[1]),
+        )
+        QGuiApplication.processEvents()
+
+        assert moved == (before[0] + 60, before[1] + 35)
+        assert not _eval(root, "windowMenu.visible")
+
+    def test_a_right_press_below_the_title_bar_does_not_open_it(self, qml_root):
+        """It is the caption strip's menu, not the keyboard's.
+
+        Right-clicking a key is already the shifted-character gesture and
+        right-clicking a pill is already the prediction menu.
+        """
+        root, _ = qml_root
+
+        _click(
+            root,
+            root.property("x") + 160,
+            root.property("y") + TITLE_BAR_HEIGHT + 80,
+            Qt.MouseButton.RightButton,
+        )
+
+        assert not _eval(root, "windowMenu.visible")
+
+
+class TestWhatTheMenuOffers:
+    def test_it_offers_move_minimize_and_close(self, qml_root):
+        root, _ = qml_root
+        _open_menu(root)
+        assert [label for label, shown in _menu_rows(root) if shown] == [
+            "Move",
+            "Minimize",
+            "Close",
+        ]
+
+    def test_the_tuck_row_collapses_where_tucking_is_impossible(self, qml_root):
+        """Tuck is X11-only, and an inert row is worse than no row.
+
+        The row is built either way (the model is not platform-conditional),
+        so this pins that it takes no height rather than merely that it is
+        missing from the labels above.
+        """
+        root, _ = qml_root
+        _open_menu(root)
+        assert not _eval(root, "root.tuckSupported"), "offscreen is not X11"
+
+        rows = dict(_menu_rows(root))
+        assert rows["Tuck away"] is False
+        assert rows["Move"] is True, "the other rows must be showing, or this proves nothing"
+        assert _eval(root, "windowMenuCol.children[2].height") == 0
+
+    def test_close_is_set_apart_from_the_rows_above_it(self, qml_root):
+        """It is the one row that ends the session, and there is no undo.
+
+        The gap is what stops an imprecise pointer aimed at Minimize landing
+        on it, so it is a property of the menu rather than decoration.
+        """
+        root, _ = qml_root
+        _open_menu(root)
+        heights = _eval(
+            root,
+            "JSON.stringify(Array.prototype.map.call("
+            "  Array.prototype.filter.call(windowMenuCol.children,"
+            "    function (c) { return c.rowLabel !== undefined && c.visible }),"
+            "  function (c) { return c.height }))",
+        )
+        move, minimize, close = json.loads(heights)
+        assert move == minimize
+        assert close > minimize
+
+    def test_choosing_move_is_what_starts_move_mode(self, qml_root):
+        root, _ = qml_root
+        _open_menu(root)
+
+        _eval(root, "windowMenu.invoke('move')")
+
+        assert _eval(root, "root.moveMode")
+        assert not _eval(root, "windowMenu.visible"), "the menu closes behind the choice"
+
+
+class TestMoveMode:
+    """The click-free drag: pick the window up, move it, put it down."""
+
+    def test_the_overlay_is_inert_until_move_mode_starts(self, qml_root):
+        """It covers the entire window, so a live one would eat every key."""
+        root, _ = qml_root
+        assert not _eval(root, "windowMoveOverlay.visible")
+        assert not _eval(root, "windowMoveOverlay.enabled")
+
+    def test_the_window_follows_the_pointer_with_no_button_held(self, qml_root):
+        root, _ = qml_root
+        start = _begin_move(root)
+
+        _hover(root, ANCHOR_GX + 45, ANCHOR_GY + 30)
+
+        assert _pos(root) == (start[0] + 45, start[1] + 30)
+
+    def test_opening_the_mode_drops_any_earlier_anchor(self, qml_root):
+        """Otherwise the second move measures against where the first one
+        ended, and the window teleports on the opening event."""
+        root, _ = qml_root
+        _begin_move(root)
+        _eval(root, "root.endWindowMove(false)")
+
+        _eval(root, "root.beginWindowMove()")
+
+        assert not _eval(root, "windowMoveOverlay.anchored")
+
+    def test_the_pointer_leaving_re_anchors_instead_of_resuming(self, qml_root):
+        """A fast flick can outrun the window it is dragging.
+
+        Measuring the way back in against the anchor the excursion started
+        from would move the window by however far the pointer travelled while
+        it was away, which is a teleport rather than a follow.  So the return
+        has to cost nothing, exactly as opening the mode does.
+        """
+        root, _ = qml_root
+        base = _begin_move(root)
+        _hover(root, ANCHOR_GX + 60, ANCHOR_GY + 40)
+        assert _pos(root) == (base[0] + 60, base[1] + 40), "the follow itself must work"
+
+        _hover(root, -400, -400)  # off the overlay entirely
+        assert not _eval(root, "windowMoveOverlay.anchored")
+        away = _pos(root)
+
+        _hover(root, ANCHOR_GX, ANCHOR_GY)
+
+        assert _pos(root) == away
+
+    def test_a_click_puts_the_keyboard_down_where_it_is(self, qml_root):
+        root, _ = qml_root
+        _begin_move(root)
+        _hover(root, ANCHOR_GX + 40, ANCHOR_GY)
+        moved = _pos(root)
+
+        _press(root, ANCHOR_GX + 40, ANCHOR_GY, Qt.MouseButton.LeftButton)
+
+        assert not _eval(root, "root.moveMode")
+        assert _pos(root) == moved
+
+    def test_a_right_click_puts_it_back_where_it_started(self, qml_root):
+        """The mode is safe to try, which is what makes it worth offering to
+        someone who cannot recover a window that lands somewhere unreachable."""
+        root, _ = qml_root
+        _park(root)
+        before = _pos(root)
+        _eval(root, "root.beginWindowMove()")
+        _hover(root, ANCHOR_GX + 60, ANCHOR_GY + 40)
+        _hover(root, ANCHOR_GX, ANCHOR_GY)
+
+        _hover(root, ANCHOR_GX + 120, ANCHOR_GY + 60)
+        assert _pos(root) != before
+
+        _press(root, ANCHOR_GX + 120, ANCHOR_GY + 60, Qt.MouseButton.RightButton)
+
+        assert not _eval(root, "root.moveMode")
+        assert _pos(root) == before
+
+    def test_the_window_stops_following_once_it_is_down(self, qml_root):
+        """The overlay is disabled on the way out, not merely hidden."""
+        root, _ = qml_root
+        _begin_move(root)
+        _eval(root, "root.endWindowMove(false)")
+        settled = _pos(root)
+
+        _hover(root, ANCHOR_GX + 200, ANCHOR_GY + 130)
+
+        assert _pos(root) == settled

--- a/tests/test_qml_window_menu.py
+++ b/tests/test_qml_window_menu.py
@@ -163,22 +163,6 @@ def _menu_rows(root) -> list[tuple[str, bool]]:
     return rows
 
 
-def _press(root, x: int, y: int, button) -> None:
-    QTest.mousePress(root, button, Qt.KeyboardModifier.NoModifier, QPoint(x, y))
-    QTest.mouseRelease(root, button, Qt.KeyboardModifier.NoModifier, QPoint(x, y))
-    QGuiApplication.processEvents()
-
-
-def _park(root) -> None:
-    """Put the window somewhere the offscreen plugin reports honestly."""
-    _eval(root, f"root.x = {PARKED_X}; root.y = {PARKED_Y}")
-    QGuiApplication.processEvents()
-
-
-def _pos(root) -> tuple[int, int]:
-    return root.property("x"), root.property("y")
-
-
 def _hover(root, gx: int, gy: int) -> None:
     """Hover-move the pointer to the *desktop* point (gx, gy).
 
@@ -191,12 +175,6 @@ def _hover(root, gx: int, gy: int) -> None:
     pointer across the desktop, not across itself.
     """
     QTest.mouseMove(root, QPoint(gx - root.property("x"), gy - root.property("y")))
-    QGuiApplication.processEvents()
-
-
-def _press(root, gx: int, gy: int, button) -> None:
-    local = QPoint(gx - root.property("x"), gy - root.property("y"))
-    QTest.mousePress(root, button, Qt.KeyboardModifier.NoModifier, local)
     QGuiApplication.processEvents()
 
 
@@ -443,7 +421,7 @@ class TestMoveMode:
         _hover(root, ANCHOR_GX + 40, ANCHOR_GY)
         moved = _pos(root)
 
-        _press(root, ANCHOR_GX + 40, ANCHOR_GY, Qt.MouseButton.LeftButton)
+        _click(root, ANCHOR_GX + 40, ANCHOR_GY, Qt.MouseButton.LeftButton)
 
         assert not _eval(root, "root.moveMode")
         assert _pos(root) == moved
@@ -461,7 +439,7 @@ class TestMoveMode:
         _hover(root, ANCHOR_GX + 120, ANCHOR_GY + 60)
         assert _pos(root) != before
 
-        _press(root, ANCHOR_GX + 120, ANCHOR_GY + 60, Qt.MouseButton.RightButton)
+        _click(root, ANCHOR_GX + 120, ANCHOR_GY + 60, Qt.MouseButton.RightButton)
 
         assert not _eval(root, "root.moveMode")
         assert _pos(root) == before


### PR DESCRIPTION
## Summary

Right-clicking the drag bar now opens the menu a real window's caption strip gives you: **Move**, **Minimize**, **Tuck away / Bring back** (X11 only), **Close**. The keyboard is frameless and `WS_EX_NOACTIVATE`, so it has no OS system menu and no gesture that reaches one (Alt+Space wants the focus we deliberately never take).

Three of the four also have a caption button a few pixels away, and that is the point rather than a redundancy: those are 28x24 targets bunched at the far right end, and the menu puts the same actions under the pointer wherever it already is on the strip the user grabs the window by.

## Type

Feature (UI only). **No prediction-engine, build/signing or telemetry changes.** Data plus QML: no backend work, nothing to mirror.

## The decisions worth reviewing

**`titleBarMenuArea` is declared before every other child of `titleBar` and accepts only `Qt.RightButton`.** Being first puts it underneath everything; taking only the right button means it consumes nothing else, so a left press still reaches `dragArea` and the caption buttons above it while a right press finds no taker up there and falls through. That is what makes the *whole* strip a menu target, buttons and the gaps between them included, rather than only the region `dragArea` covers (which stops 332 px short of the right edge).

The failure mode to avoid is declaring it on top, which would silently kill dragging the window. `dragArea` shields it well enough that "a left press does not open the menu" is not a falsifiable test, so the guard presses, travels and asserts the window followed instead.

**Move is the one entry with no button behind it, and the reason the menu earns its place.** Dragging the bar means holding the button down for the whole travel, which is the single gesture this keyboard's user cannot reliably make (the same argument that removed swipe typing). Move mode splits it into two taps with a free hand in between: pick the window up, move it, put it down.

- The follow is `(current - anchor)` in the overlay's own coordinates, which is self-correcting: the window slides out from under the pointer by exactly the delta, putting the pointer back on the anchor and making the next delta zero. It converges instead of running away and needs no global coordinates.
- The anchor is dropped on `onExited` as well as on open, so a flick that outruns the window re-anchors on the way back in rather than teleporting by however far the excursion went.
- The overlay covers the whole window and is `enabled: root.moveMode`, not merely hidden: it has to swallow the click that ends the move, or that click lands on a key, a pill or Close.
- Left places, right cancels back to the starting position. There is no Escape, because this window never holds focus: a physical Escape goes to the app behind us and the OSK's own Esc key is synthesised into that app too. A hint banner on the overlay says which click does which, since the mode otherwise has no tell.

**Close sits under a rule and a 9 px gap.** It is the one row that ends the session, there is no undo, and it must not be flush against Minimize under an imprecise pointer. The Tuck row is built unconditionally and collapses to zero height off X11, because a row for something that cannot happen is worse than no row. Rows come from a model rather than four near-identical blocks, and are word-only: any glyph small enough for a menu row is at the mercy of the host emoji font, which on Windows renders in colour and ignores the ink it is given.

**The menu is painted in the theme's key colour**, which is what a raised surface is made of everywhere else here. Deriving it from the window background was tried and rendered: on the dark themes that background is already near-black, so a darkened copy reads as a hole rather than a panel, and on Typewriter's cream the same expression has to go the other way to work at all.

## Test plan

`tests/test_qml_window_menu.py`, 15 headless tests that load the real `Main.qml` under the offscreen plugin and drive real `QTest` mouse events. Mutation-checked six ways; five caught. The sixth (`onVisibleChanged: anchored = false`) turned out to be redundant with `onExited`, because Qt fires an exit when an item under the pointer is hidden. The line is kept and its comment says exactly that rather than claiming coverage it does not have.

Three offscreen-plugin traps are pinned in that file so the next person does not rediscover them:

- The pointer is driven in **desktop** coordinates, not window-local ones. In move mode the two are not interchangeable: the window slides by exactly the delta, so the same local point maps back to the same global point and Qt drops the second event as a duplicate.
- A window parked at a negative x is reported 4 px adrift of where it was put, so a 45 px move measures as 49. Hence `PARKED_X`/`PARKED_Y`.
- A closed `Popup`'s rows all report `visible: false`, so any assertion about which rows are showing has to open the menu first or it passes against anything at all.

`python check.py` passes (ruff, format, mypy under both platforms, full pytest). Rendered and eyeballed on Dark and Typewriter, plus the move-mode hint.

## Accessibility check

This is the accessibility change. Move mode exists specifically because a sustained precise hold is the gesture that does not work here, and it is cancellable so it is safe to try for someone who could not recover a window that landed somewhere unreachable. Menu rows are 40 px rather than the 34 the pill menu uses, and the whole caption strip is the trigger rather than a small hotspot. No change to keystroke timing, repeat interval, or any existing visual feedback.
