### PR TITLE
fix(dictation): keep the API key out of the config's repr

### DIFF
--- a/src/dictation/config.py
+++ b/src/dictation/config.py
@@ -35,6 +35,7 @@ import json
 import logging
 import sys
 from dataclasses import dataclass, field
+from dataclasses import fields as dataclass_fields
 from pathlib import Path
 from typing import Any
 
@@ -242,6 +243,23 @@ class DictationConfig:
     #: When off, the transcript accumulates in the suggestion bar and is
     #: inserted in one go when the user stops.
     stream_inserts: bool = True
+
+    # Hand-written rather than dataclass-generated.  A generated repr puts
+    # the key into every log line, f-string and traceback that formats this
+    # object, and the diagnostic log is the file users attach to bug
+    # reports.  The docstring above says nothing here is ever logged, which
+    # is true of today's call sites and is exactly the kind of promise the
+    # next one breaks in silence; this makes it true by construction rather
+    # than by everyone remembering.  It walks the fields rather than naming
+    # them so a field added later is carried without a second edit.
+    def __repr__(self) -> str:
+        parts = []
+        for f in dataclass_fields(self):
+            if f.name == "api_key":
+                parts.append(f"api_key={'<set>' if self.api_key else '<unset>'}")
+            else:
+                parts.append(f"{f.name}={getattr(self, f.name)!r}")
+        return f"{type(self).__name__}({', '.join(parts)})"
 
     @property
     def has_key(self) -> bool:

--- a/tests/test_dictation.py
+++ b/tests/test_dictation.py
@@ -168,6 +168,34 @@ class TestTheKeyNeverLeavesTheMachine:
     fix and would ship a key inside every backup a user makes.
     """
 
+    def test_formatting_the_config_never_prints_the_key(self):
+        """A generated repr would carry the key into any line that formats it.
+
+        Nothing formats the config today, which is the reason this is a
+        test and not a comment: the leak arrives with the first
+        ``_logger.debug("%s", cfg)`` somebody adds, and it lands in the
+        diagnostic log, which is the file users attach to bug reports.
+        """
+        secret = "sk-supersecret-0123456789abcdef01234567"
+        cfg = DictationConfig(api_key=secret, enabled=True)
+
+        for rendered in (repr(cfg), str(cfg), f"{cfg}", "%s" % (cfg,)):
+            assert secret not in rendered
+            assert "supersecret" not in rendered
+
+    def test_the_redacted_repr_still_says_whether_a_key_is_set(self):
+        """The inverse: redaction that erases the distinction is useless.
+
+        A repr that simply dropped the field would satisfy the test above
+        while leaving anyone reading a bug report unable to tell a missing
+        key from a wrong one, which is the first question dictation
+        support asks.  The ``model`` assertion pins the other half: the
+        hand-written repr still has to render the fields it is not hiding.
+        """
+        assert "api_key=<set>" in repr(DictationConfig(api_key="k" * 40))
+        assert "api_key=<unset>" in repr(DictationConfig())
+        assert "model='nova-3'" in repr(DictationConfig())
+
     def test_dictation_json_is_not_in_the_export_manifest(self):
         from src import data_export
 


### PR DESCRIPTION
## Summary

- `DictationConfig` was a plain `@dataclass` with `api_key: str = ""` and no repr override, so the generated `__repr__` printed the Deepgram key in full.
- Nothing formats the config object today, so this had not leaked. That is a property of the current call sites, not of the type: the first `_logger.debug("%s", cfg)` anyone adds writes a live credential into `alpha-osk.log`, which is the file bug reports attach and the file `_install_exception_hooks` routes uncaught tracebacks into.
- The repr is now hand-written. It walks the dataclass fields, so a field added later is carried without a second edit, and renders the key as `<set>` / `<unset>` rather than dropping it, because a reader still has to tell a missing key from a wrong one.

Found while reviewing an unrelated Deepgram credential change in MacroVox, which hand-writes its Rust `Debug` impl for exactly this reason. The rest of that work does not apply here: alpha-osk has no managed or shared credential, dictation is bring-your-own-key, and the cf-worker holds no vendor key at all.

## Related issue

No issue. Drive-by hardening on the file that already carries the "never logged, never returned to QML in the clear" rule.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Docs only
- [ ] Build / CI / tooling
- [ ] Other (describe)

Latent rather than live: no known path formats the object today.

## Test plan

Two tests in the existing `TestTheKeyNeverLeavesTheMachine`, which is already the home of this rule:

- `test_formatting_the_config_never_prints_the_key` covers `repr()`, `str()`, an f-string and `%s`.
- `test_the_redacted_repr_still_says_whether_a_key_is_set` is the inverse. A repr that simply dropped the field would pass the first test while making a bug report less useful, so this pins `<set>` / `<unset>`, plus `model='nova-3'` to pin that the hand-written repr still renders the fields it is not hiding.

Both fail against the previous code, printing all 40 characters of the key into the assertion message.

- [x] `python check.py` passes locally (77s, all five gates)
- [x] Added or updated tests
- [ ] Tested in `python run.py` (not just frozen build)
- [x] Verified on Windows (test suite)
- [ ] Verified on Linux
- [ ] Verified on macOS

Not exercised in a running app: the change is confined to `__repr__`, which no code path calls.

## Accessibility check

n/a. No keystroke timing, repeat behaviour, visual feedback or precision is touched.

## Notes for reviewers

- The class docstring already said "Nothing here is ever logged: `save` and `load` log counts and booleans only." That stays true and is now enforced by the type instead of by everyone remembering.
- One nit deliberately left alone: `masked_key()` reveals 8 of 9 characters for a 9 to 11 character key. Deepgram keys are 40 hex characters, so it is theoretical, and changing it would move a shipped preview format for no real gain.
