### PR TITLE
fix(security): close five findings from a repo security review

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -2294,9 +2294,45 @@ Window {
                             // Reveal the full word on hover when the pill
                             // clipped it — predText.truncated is true only
                             // when ElideRight actually had to chop.
-                            ToolTip.visible: predMouse.containsMouse && predText.truncated
-                            ToolTip.text: modelData
-                            ToolTip.delay: 400
+                            //
+                            // Declared as a real ToolTip rather than through
+                            // the `ToolTip.text` attached property, because
+                            // the attached idiom gives no way to set
+                            // textFormat and Qt's default is AutoText, which
+                            // sniffs the string for HTML. A prediction can
+                            // come from an imported vocabulary pack's
+                            // unsanitised dictionary.txt (predText says the
+                            // same, which is why it pins PlainText), and the
+                            // only pill that is ever truncated — so the only
+                            // one this tooltip shows — is a single word wider
+                            // than the whole bar, i.e. exactly the crafted
+                            // one. An <img> in it would make Qt fetch the URL
+                            // on hover, from an app whose whole promise is
+                            // that nothing leaves the machine.
+                            ToolTip {
+                                id: predTip
+                                visible: predMouse.containsMouse && predText.truncated
+                                delay: 400
+                                contentItem: Text {
+                                    text: modelData
+                                    textFormat: Text.PlainText
+                                    // The flat theme properties, not
+                                    // root.theme.*: a Popup's contentItem is
+                                    // built in its own scope and the grouped
+                                    // object reads as undefined there, which
+                                    // the QML-warning gate catches as a
+                                    // TypeError on every pill.
+                                    color: root.themeTextColor
+                                    font.pixelSize: predBar.predFontSize
+                                    font.family: "Ubuntu, Noto Sans, sans-serif"
+                                }
+                                background: Rectangle {
+                                    color: root.themeKeyColor
+                                    border.color: root.themeBorder
+                                    border.width: 1
+                                    radius: 4
+                                }
+                            }
 
                             // Smooth hover animation
                             Behavior on color { ColorAnimation { duration: 100 } }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -2303,8 +2303,8 @@ Window {
                             // come from an imported vocabulary pack's
                             // unsanitised dictionary.txt (predText says the
                             // same, which is why it pins PlainText), and the
-                            // only pill that is ever truncated — so the only
-                            // one this tooltip shows — is a single word wider
+                            // only pill that is ever truncated (so the only
+                            // one this tooltip shows) is a single word wider
                             // than the whole bar, i.e. exactly the crafted
                             // one. An <img> in it would make Qt fetch the URL
                             // on hover, from an app whose whole promise is

--- a/src/atomic_write.py
+++ b/src/atomic_write.py
@@ -75,6 +75,17 @@ def atomic_write_json(
     Serialisation happens before any file is touched, so a value that
     ``json.dumps`` refuses (a non-serialisable object, a circular
     reference) never creates a temp file at all.
+
+    ``allow_nan=False`` is deliberate and load-bearing.  ``json.load``
+    accepts bare ``NaN`` / ``Infinity`` (they are not legal JSON, but
+    Python emits and reads them by default), and every store here is
+    replace-on-import from an archive the user picked.  With the default
+    ``allow_nan=True`` a NaN count smuggled in through one import is
+    read into memory, survives scoring as a value that compares False
+    against everything, and is then **written straight back out** on the
+    next save -- so a single hostile or corrupt archive corrupts the
+    user's real model permanently, across restarts.  Refusing at the
+    write boundary turns that into a loud, recoverable failure instead.
     """
-    text = json.dumps(data, indent=indent, ensure_ascii=ensure_ascii)
+    text = json.dumps(data, indent=indent, ensure_ascii=ensure_ascii, allow_nan=False)
     atomic_write_text(path, text, mode=mode)

--- a/src/keyboard_app.py
+++ b/src/keyboard_app.py
@@ -665,8 +665,14 @@ def main() -> int:
     _install_exception_hooks()
     if log_path is not None:
         _logger.info("Log file: %s", log_path)
-    # Enable debug logging for prediction to see sources
-    logging.getLogger("HybridPredictor").setLevel(logging.DEBUG)
+    # NOTE: do not force any logger to DEBUG here.  The prediction path
+    # logs its candidate words at DEBUG (see HybridPredictor._merge_*),
+    # and the handlers installed above carry no level of their own, so a
+    # logger pinned to DEBUG writes those words straight into
+    # alpha-osk.log -- the file users attach to bug reports.  DEBUG is
+    # the sanctioned place for typed content precisely because it is off
+    # in normal operation; turning it on unconditionally is what broke
+    # that.  Raise the level by hand while debugging, never in main().
 
     # Platform-specific environment setup (must happen before QApp)
     _setup_platform_env()

--- a/src/keyboard_bridge.py
+++ b/src/keyboard_bridge.py
@@ -3521,8 +3521,20 @@ class KeyboardBridge(QObject):
 
     @Slot()
     def savePredictionModel(self) -> None:
-        """Save the prediction model to disk."""
-        self._predictor.save()
+        """Save the prediction model to disk.
+
+        Failures are logged rather than raised.  This runs from the
+        Settings "Save Now" button and from ``aboutToQuit``, and a raise
+        on the quit path leaves the rest of the shutdown sequence
+        (analytics, telemetry, modifier release) unrun.  It also has to
+        survive ``atomic_write_json`` refusing a non-finite count, which
+        it now does deliberately: refusing leaves the previous good file
+        on disk, which is the outcome worth protecting.
+        """
+        try:
+            self._predictor.save()
+        except Exception as exc:  # noqa: BLE001 - never break the quit path
+            _logger.error("Saving the prediction model failed: %s", exc)
 
     # ------------------------------------------------------------------
     #  Diagnostic log (the file users attach to a bug report)

--- a/src/keyboard_bridge.py
+++ b/src/keyboard_bridge.py
@@ -4285,8 +4285,18 @@ class KeyboardBridge(QObject):
     def clearUserData(self) -> None:
         """Clear user-learned vocabulary and overwrite saved models on disk."""
         self._predictor.clear_user_data()
-        # Save immediately so stale model files don't restore old data on restart
-        self._predictor.save()
+        # Save immediately so stale model files don't restore old data on
+        # restart.  Guarded for the same reason savePredictionModel is:
+        # save() can refuse a write, and this is the third of its three
+        # call sites, so leaving it bare is how the three drift apart.
+        # The clear itself has already happened in memory either way, so
+        # a failure here means the on-disk files are stale, which is
+        # exactly what the log line needs to stop claiming.
+        try:
+            self._predictor.save()
+        except Exception as exc:  # noqa: BLE001 - the clear already happened
+            _logger.error("Clearing user data succeeded but the save failed: %s", exc)
+            return
         _logger.info("User data cleared and model files overwritten")
 
     @Slot()

--- a/src/platform/__init__.py
+++ b/src/platform/__init__.py
@@ -46,6 +46,7 @@ See also: ``docs/architecture/PLATFORM_ARCHITECTURE.md`` for detailed design rat
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -216,6 +217,30 @@ def get_log_path() -> Path:
     return get_config_dir() / LOG_FILENAME
 
 
+def powershell_path() -> str:
+    """Return an absolute path to Windows PowerShell.
+
+    Never invoke ``powershell`` by bare name.  ``CreateProcess`` with no
+    explicit application name searches the launching process's own
+    directory and then **the current working directory** before it
+    reaches System32, so a ``powershell.exe`` dropped into whichever
+    folder we happen to be running from wins over the real one.  That
+    matters most on the auto-update path, where the PowerShell call is
+    the whole Authenticode trust gate: a planted binary that prints a
+    convincing ``Valid|<thumbprint>|<CN>|<version>`` line defeats
+    signature verification outright.
+
+    ``shutil.which`` is deliberately not used as a fallback -- on Windows
+    it prepends the current directory to the search path, which is the
+    exact hole this closes.  If the resolved path does not exist the
+    caller's ``subprocess`` raises ``FileNotFoundError`` and every caller
+    here already treats that as failure, so the trust gate fails closed
+    rather than falling back to a name lookup.
+    """
+    system_root = os.environ.get("SystemRoot") or r"C:\Windows"
+    return os.path.join(system_root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+
+
 def _check_ui_access() -> bool:
     """
     Check whether the current process has UIAccess privileges on Windows.
@@ -295,5 +320,6 @@ __all__ = [
     "get_platform_info",
     "get_config_dir",
     "get_log_path",
+    "powershell_path",
     "get_model_dir",
 ]

--- a/src/platform/__init__.py
+++ b/src/platform/__init__.py
@@ -46,6 +46,7 @@ See also: ``docs/architecture/PLATFORM_ARCHITECTURE.md`` for detailed design rat
 from __future__ import annotations
 
 import logging
+import ntpath
 import os
 import sys
 from pathlib import Path
@@ -238,7 +239,11 @@ def powershell_path() -> str:
     rather than falling back to a name lookup.
     """
     system_root = os.environ.get("SystemRoot") or r"C:\Windows"
-    return os.path.join(system_root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+    # ``ntpath``, not ``os.path``: this builds a Windows path whatever the
+    # host is, so the result is well formed (and recognisably absolute)
+    # when the tests exercise it on Linux.  On Windows the two are the
+    # same module.
+    return ntpath.join(system_root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
 
 
 def _check_ui_access() -> bool:

--- a/src/platform/windows.py
+++ b/src/platform/windows.py
@@ -83,6 +83,7 @@ import logging
 import time
 from typing import Dict, List, Optional, Tuple
 
+from . import powershell_path
 from .base import KeySynthesizerBase
 
 _logger = logging.getLogger("WindowsKeySynthesizer")
@@ -1288,7 +1289,10 @@ def create_shortcut(
         import subprocess
 
         result = subprocess.run(
-            ["powershell", "-NoProfile", "-Command", ps_script],
+            # Absolute path, never the bare name: CreateProcess searches
+            # the CWD before System32, so a planted powershell.exe in
+            # whatever folder we were launched from would run instead.
+            [powershell_path(), "-NoProfile", "-Command", ps_script],
             capture_output=True,
             text=True,
             timeout=10,

--- a/src/prediction/ngram_predictor.py
+++ b/src/prediction/ngram_predictor.py
@@ -1473,9 +1473,17 @@ class NgramPredictor:
                     len(self.bigrams),
                     len(self.trigrams),
                 )
+            # Rebuild the incremental running total BEFORE publishing
+            # either field.  A non-numeric count in a crafted or corrupt
+            # file makes sum() raise, and assigning user_vocab first left
+            # it holding the poisoned data while _user_total kept its
+            # stale value -- durably breaking the
+            # `_user_total == sum(user_vocab.values())` invariant for the
+            # rest of the session, since nothing recomputes it.  Computing
+            # into a local makes the pair atomic against that raise.
+            user_total = sum(user_vocab_clean.values())
             self.user_vocab = defaultdict(int, user_vocab_clean)
-            # Rebuild incremental running total from loaded counts.
-            self._user_total = sum(self.user_vocab.values())
+            self._user_total = user_total
             self.total_words = data.get("total_words", 0)
             self.blacklist = set(data.get("blacklist", []))
             self.dispreference = defaultdict(int, data.get("dispreference", {}))

--- a/src/prediction/ngram_predictor.py
+++ b/src/prediction/ngram_predictor.py
@@ -1086,25 +1086,29 @@ class NgramPredictor:
         """Permanently suppress a word from predictions."""
         self.blacklist.add(word.lower())
         self._blacklist_type_count.pop(word.lower(), None)
-        _logger.info("Blacklisted word: %s", word)
+        _logger.info("Blacklisted a word (len=%d)", len(word))
 
     def unblacklist_word(self, word: str) -> None:
         """Re-enable a previously blacklisted word."""
         self.blacklist.discard(word.lower())
         self._blacklist_type_count.pop(word.lower(), None)
-        _logger.info("Unblacklisted word: %s", word)
+        _logger.info("Unblacklisted a word (len=%d)", len(word))
 
     def mark_bad(self, word: str) -> None:
         """Downweight a word in future predictions."""
         self.dispreference[word.lower()] += 1
-        _logger.info("Marked bad: %s (weight now %d)", word, self.dispreference[word.lower()])
+        _logger.info(
+            "Marked a word bad (len=%d, weight now %d)",
+            len(word),
+            self.dispreference[word.lower()],
+        )
 
     def remove_dispreference(self, word: str) -> None:
         """Remove dispreference penalty from a word."""
         word_lower = word.lower()
         if word_lower in self.dispreference:
             del self.dispreference[word_lower]
-            _logger.info("Removed dispreference: %s", word)
+            _logger.info("Removed a dispreference (len=%d)", len(word))
 
     def mark_good(self, word: str) -> None:
         """Boost a word and record the boost so it can be undone.
@@ -1119,7 +1123,11 @@ class NgramPredictor:
             return
         self.learn_word(word_lower)
         self.preferred[word_lower] += 5
-        _logger.info("Marked good: %s (boost now %d)", word, self.preferred[word_lower])
+        _logger.info(
+            "Marked a word good (len=%d, boost now %d)",
+            len(word),
+            self.preferred[word_lower],
+        )
 
     def unprefer(self, word: str) -> None:
         """Roll back an explicit user boost.
@@ -1145,7 +1153,7 @@ class NgramPredictor:
             if self.unigrams.get(word_lower, 0) <= 0:
                 self.unigrams.pop(word_lower, None)
         del self.preferred[word_lower]
-        _logger.info("Unpreferred: %s (rolled back %d)", word, rollback)
+        _logger.info("Unpreferred a word (len=%d, rolled back %d)", len(word), rollback)
 
     def get_preference(self, word: str) -> int:
         """Get the explicit boost count for a word (0 if not boosted)."""
@@ -1173,8 +1181,8 @@ class NgramPredictor:
             if self._blacklist_type_count[word_lower] >= self._rehabilitate_threshold:
                 self.unblacklist_word(word_lower)
                 _logger.info(
-                    "Auto-rehabilitated word: %s (typed %d times)",
-                    word_lower,
+                    "Auto-rehabilitated a word (len=%d, typed %d times)",
+                    len(word_lower),
                     self._rehabilitate_threshold,
                 )
                 return word_lower

--- a/src/updater.py
+++ b/src/updater.py
@@ -75,6 +75,7 @@ from typing import Callable, Optional, Tuple
 from urllib.parse import urlparse
 
 from .__version__ import __version__ as CURRENT_VERSION
+from .platform import powershell_path
 
 _logger = logging.getLogger("Updater")
 
@@ -464,7 +465,10 @@ def _verify_signature(exe_path: Path, expected_version: str) -> bool:
 
     try:
         result = subprocess.run(
-            ["powershell", "-NoProfile", "-NonInteractive", "-Command", ps_script],
+            # Absolute path, never the bare name: CreateProcess searches
+            # the CWD before System32, and this call *is* the signature
+            # check.  See platform.powershell_path.
+            [powershell_path(), "-NoProfile", "-NonInteractive", "-Command", ps_script],
             capture_output=True,
             text=True,
             timeout=30,

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import stat
 import sys
@@ -81,3 +82,45 @@ class TestAtomicWriteJson:
 
         assert not path.exists()
         assert list(tmp_path.iterdir()) == []
+
+
+class TestNonFiniteNumbersAreRefused:
+    """``allow_nan=False`` is a security property, not tidiness.
+
+    ``json.load`` accepts bare ``NaN`` / ``Infinity`` (Python emits and
+    reads them by default even though they are not legal JSON), and every
+    store here is replace-on-import from an archive the user picked.
+    Without the refusal a poisoned count is read in, survives scoring as a
+    value that compares False against everything, and is written straight
+    back out on the next save -- corrupting the user's real model
+    permanently.  Refusing at the write boundary leaves the previous good
+    file on disk instead.
+    """
+
+    def test_nan_is_refused(self, tmp_path: Path) -> None:
+        dest = tmp_path / "model.json"
+        with pytest.raises(ValueError):
+            atomic_write_json(dest, {"user_vocab": {"hi": float("nan")}})
+
+    def test_infinity_is_refused(self, tmp_path: Path) -> None:
+        dest = tmp_path / "model.json"
+        with pytest.raises(ValueError):
+            atomic_write_json(dest, {"user_vocab": {"hi": float("inf")}})
+
+    def test_a_refusal_leaves_the_previous_file_untouched(self, tmp_path: Path) -> None:
+        """The whole point: the good file survives the bad write."""
+        dest = tmp_path / "model.json"
+        atomic_write_json(dest, {"user_vocab": {"hi": 3}})
+        before = dest.read_text(encoding="utf-8")
+
+        with pytest.raises(ValueError):
+            atomic_write_json(dest, {"user_vocab": {"hi": float("nan")}})
+
+        assert dest.read_text(encoding="utf-8") == before
+        assert not list(tmp_path.glob("*.tmp*"))
+
+    def test_ordinary_numbers_still_write(self, tmp_path: Path) -> None:
+        """The inverse, so a blanket refusal could not pass this class."""
+        dest = tmp_path / "model.json"
+        atomic_write_json(dest, {"user_vocab": {"hi": 3, "there": 2.5}})
+        assert json.loads(dest.read_text(encoding="utf-8"))["user_vocab"]["there"] == 2.5

--- a/tests/test_keyboard_app.py
+++ b/tests/test_keyboard_app.py
@@ -95,6 +95,34 @@ class TestPurgePreFixLogs:
         assert removed == 0
 
 
+@pytest.fixture
+def _restore_root_logging() -> Iterator[None]:
+    """``_configure_logging`` replaces the root handlers process-wide.
+
+    The suite shards with xdist, so leaving them swapped would break
+    whatever ran next in this worker (caplog included).  The handler it
+    opened is also closed here, or Windows will not let tmp_path be
+    cleaned up afterwards.  Shared by every class in this file that runs
+    the real logging setup.
+    """
+    root = logging.getLogger()
+    original = list(root.handlers)
+    level = root.level
+    named = logging.getLogger("HybridPredictor")
+    named_level = named.level
+    try:
+        yield
+    finally:
+        for handler in list(root.handlers):
+            root.removeHandler(handler)
+            if handler not in original:
+                handler.close()
+        for handler in original:
+            root.addHandler(handler)
+        root.setLevel(level)
+        named.setLevel(named_level)
+
+
 class TestTheLogGoesWhereTheUIPointsUsers:
     """*Settings -> Data & Privacy -> Diagnostics* shows a path.
 
@@ -103,29 +131,6 @@ class TestTheLogGoesWhereTheUIPointsUsers:
     nothing writes is worse than no panel, so this pins the two
     together rather than asserting either one on its own.
     """
-
-    @pytest.fixture
-    def _restore_root_logging(self) -> Iterator[None]:
-        """``_configure_logging`` replaces the root handlers process-wide.
-
-        The suite shards with xdist, so leaving them swapped would break
-        whatever ran next in this worker (caplog included).  The handler
-        it opened is also closed here, or Windows will not let tmp_path
-        be cleaned up afterwards.
-        """
-        root = logging.getLogger()
-        original = list(root.handlers)
-        level = root.level
-        try:
-            yield
-        finally:
-            for handler in list(root.handlers):
-                root.removeHandler(handler)
-                if handler not in original:
-                    handler.close()
-            for handler in original:
-                root.addHandler(handler)
-            root.setLevel(level)
 
     def test_the_handler_writes_the_file_the_panel_names(
         self,
@@ -144,6 +149,61 @@ class TestTheLogGoesWhereTheUIPointsUsers:
         assert opened == platform_mod.get_log_path()
         assert opened is not None
         assert "a record" in opened.read_text(encoding="utf-8")
+
+
+class TestTypedContentNeverReachesTheLog:
+    """The prediction path logs its candidate words at DEBUG.
+
+    That is allowed: DEBUG is the sanctioned home for typed content
+    precisely because it is off in an ordinary session.  What is not
+    allowed is pinning that logger to DEBUG at startup, which ``main()``
+    used to do unconditionally -- the handlers ``_configure_logging``
+    installs carry no level of their own, so every pill row the engine
+    produced was written into the file users attach to bug reports.
+
+    Two tests, because neither alone is honest.  The first states the
+    property end to end; the second is what actually catches the line
+    coming back, since the property test cannot run ``main()``.
+    """
+
+    def test_a_prediction_debug_record_does_not_reach_the_log_file(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _restore_root_logging: None,
+    ) -> None:
+        """A default session must not write engine DEBUG records to disk."""
+        import src.platform as platform_mod
+
+        monkeypatch.setattr(platform_mod, "get_config_dir", lambda: tmp_path)
+        monkeypatch.setattr(keyboard_app, "get_config_dir", lambda: tmp_path)
+
+        opened = _configure_logging()
+        assert opened is not None
+
+        # Exactly what HybridPredictor emits on every keystroke.
+        logging.getLogger("HybridPredictor").debug("MERGED result: %s", ["hunter2", "passphrase"])
+        # An INFO record on the same logger proves the file is live, so a
+        # test that passed because nothing was written at all would fail.
+        logging.getLogger("HybridPredictor").info("engine ready")
+
+        written = opened.read_text(encoding="utf-8")
+        assert "engine ready" in written
+        assert "hunter2" not in written
+        assert "MERGED result" not in written
+
+    def test_main_pins_no_logger_to_debug(self) -> None:
+        """Source-level guard, deliberately.
+
+        ``main()`` builds a QApplication and enters an event loop, so the
+        property test above cannot execute it, and the defect lived in a
+        single statement there.  Asserting on the source is brittle in
+        the usual way but it is the only thing that fails if the line is
+        restored, which is the whole point of the guard.
+        """
+        source = Path(keyboard_app.__file__).read_text(encoding="utf-8")
+        body = source.split("def main(", 1)[1]
+        assert "setLevel(logging.DEBUG)" not in body
 
 
 def _boom() -> tuple:

--- a/tests/test_ngram_predictor.py
+++ b/tests/test_ngram_predictor.py
@@ -989,3 +989,40 @@ class TestTheModelLoggerNeverWritesAWord:
         assert "hunter2" not in emitted
         assert "len=7" in emitted
 
+
+class TestACraftedModelCannotDesyncTheUserTotal:
+    """``_user_total == sum(user_vocab.values())`` is a stated invariant.
+
+    ``load`` used to publish ``user_vocab`` and *then* compute the total
+    from it, so a non-numeric count made ``sum`` raise into the blanket
+    handler and left the poisoned table in place beside a stale total.
+    Nothing recomputes it, so the invariant stayed broken for the rest of
+    the session and every later increment compounded on a wrong baseline.
+    """
+
+    def test_a_non_numeric_count_leaves_the_invariant_intact(self, tmp_path: Path) -> None:
+        predictor = NgramPredictor()
+        predictor.user_vocab["real"] = 4
+        predictor._user_total = 4
+
+        hostile = tmp_path / "ngram_model.json"
+        hostile.write_text(
+            json.dumps({"unigrams": {}, "user_vocab": {"hello": "not-a-number"}}),
+            encoding="utf-8",
+        )
+        predictor.load(hostile)
+
+        assert predictor._user_total == sum(predictor.user_vocab.values())
+
+    def test_a_well_formed_file_still_loads(self, tmp_path: Path) -> None:
+        """The inverse half: the guard must not refuse a good file."""
+        predictor = NgramPredictor()
+        good = tmp_path / "ngram_model.json"
+        good.write_text(
+            json.dumps({"unigrams": {}, "user_vocab": {"hello": 3, "there": 2}}),
+            encoding="utf-8",
+        )
+        predictor.load(good)
+
+        assert predictor._user_total == 5
+        assert predictor._user_total == sum(predictor.user_vocab.values())

--- a/tests/test_ngram_predictor.py
+++ b/tests/test_ngram_predictor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import logging
 import os
 from pathlib import Path
 
@@ -934,3 +936,56 @@ class TestReinforceContext:
         p = NgramPredictor()
         p.reinforce_context("hello", "World")
         assert p.bigrams["hello"]["world"] == 1
+
+
+class TestTheModelLoggerNeverWritesAWord:
+    """``alpha-osk.log`` is the file users attach to bug reports.
+
+    These six paths all take a word the user typed or was offered, and
+    they log at INFO, so they reach that file in every ordinary session.
+    ``forget_token`` deliberately logs nothing at all for exactly this
+    reason; these were the inconsistency.  Each case asserts the shape is
+    still reported, so a fix that simply deleted the logging would not
+    pass.
+    """
+
+    @pytest.mark.parametrize(
+        "action",
+        [
+            lambda p: p.blacklist_word("hunter2"),
+            lambda p: p.unblacklist_word("hunter2"),
+            lambda p: p.mark_bad("hunter2"),
+            lambda p: p.mark_good("hunter2"),
+        ],
+    )
+    def test_the_word_is_not_in_the_log_record(self, action, caplog) -> None:
+        predictor = NgramPredictor()
+        with caplog.at_level(logging.INFO, logger="NgramPredictor"):
+            action(predictor)
+
+        emitted = " ".join(r.getMessage() for r in caplog.records)
+        assert "hunter2" not in emitted
+        assert "len=7" in emitted
+
+    def test_removing_a_dispreference_reports_only_the_shape(self, caplog) -> None:
+        predictor = NgramPredictor()
+        predictor.mark_bad("hunter2")
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="NgramPredictor"):
+            predictor.remove_dispreference("hunter2")
+
+        emitted = " ".join(r.getMessage() for r in caplog.records)
+        assert "hunter2" not in emitted
+        assert "len=7" in emitted
+
+    def test_rolling_back_a_boost_reports_only_the_shape(self, caplog) -> None:
+        predictor = NgramPredictor()
+        predictor.mark_good("hunter2")
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="NgramPredictor"):
+            predictor.unprefer("hunter2")
+
+        emitted = " ".join(r.getMessage() for r in caplog.records)
+        assert "hunter2" not in emitted
+        assert "len=7" in emitted
+

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -1071,3 +1072,46 @@ class TestPlatformInfo:
 
         info = get_platform_info()
         assert "python" in info
+
+
+class TestPowerShellIsNeverInvokedByBareName:
+    """``CreateProcess`` searches the CWD before System32.
+
+    With no explicit application name, Windows resolves a bare
+    ``powershell`` against the launching process's own directory and then
+    the current working directory, ahead of System32.  The updater's
+    signature check is a PowerShell call, and it is the entire
+    Authenticode trust gate for auto-update: a planted ``powershell.exe``
+    that prints a convincing ``Valid|<thumbprint>|<CN>|<version>`` line
+    defeats it outright.  So the path has to be absolute at every call
+    site, and ``shutil.which`` is not an acceptable fallback because on
+    Windows it prepends the current directory to the search path -- the
+    exact hole being closed.
+    """
+
+    def test_the_helper_returns_an_absolute_system32_path(self) -> None:
+        from src.platform import powershell_path
+
+        resolved = powershell_path()
+        assert os.path.isabs(resolved)
+        assert resolved.lower().endswith("powershell.exe")
+        assert "system32" in resolved.lower()
+
+    def test_the_helper_follows_system_root(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Not hardcoded to C:, for hosts installed on another volume."""
+        from src.platform import powershell_path
+
+        monkeypatch.setenv("SystemRoot", r"D:\Windows")
+        assert powershell_path().startswith(r"D:\Windows")
+
+    @pytest.mark.parametrize(
+        "source",
+        ["src/updater.py", "src/platform/windows.py"],
+    )
+    def test_no_call_site_passes_a_bare_name(self, source: str) -> None:
+        """The guard that fails if either call site regresses."""
+        text = Path(source).read_text(encoding="utf-8")
+        assert '"powershell"' not in text, (
+            f"{source} invokes powershell by bare name; use "
+            "platform.powershell_path() so CWD cannot win"
+        )

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os
+import ntpath
 import subprocess
 import sys
 from pathlib import Path
@@ -1093,7 +1093,10 @@ class TestPowerShellIsNeverInvokedByBareName:
         from src.platform import powershell_path
 
         resolved = powershell_path()
-        assert os.path.isabs(resolved)
+        # ntpath, not os.path: the helper builds a Windows path on every
+        # host, and posixpath.isabs() does not recognise a drive letter,
+        # so os.path.isabs() would fail this on the Linux CI shard.
+        assert ntpath.isabs(resolved)
         assert resolved.lower().endswith("powershell.exe")
         assert "system32" in resolved.lower()
 

--- a/tests/test_qml_prediction_bar.py
+++ b/tests/test_qml_prediction_bar.py
@@ -669,3 +669,40 @@ class TestPillTextNeverAutoDetectsHtml:
                 "a prediction pill is not forced to Text.PlainText -- an "
                 "imported pack word containing markup could auto-render as HTML"
             )
+
+
+class TestThePillTooltipNeverAutoDetectsHtml:
+    """The hover tooltip is the other half of the pill, and it was missed.
+
+    ``predText`` pins ``Text.PlainText`` (see the class above).  The
+    tooltip that reveals the *same* string did not, because it was written
+    with the ``ToolTip.text`` attached property, which exposes no
+    ``textFormat`` and so inherits Qt's ``AutoText`` HTML sniffing.
+
+    That is not a lesser surface than the pill itself, it is a sharper
+    one: per the bar's own fitter the only pill ever truncated is a single
+    word wider than the whole bar, and the tooltip is shown only when
+    truncated, so the one string it renders is the overlong one -- exactly
+    the shape a hostile ``dictionary.txt`` entry has.
+    """
+
+    def test_the_tooltip_content_is_plain_text(self, qml_root):
+        root, warnings, _ = qml_root
+        _show(root, ["hello", "<b>world</b>", "world"])
+        pills = expect_pills(root)
+
+        for pill in pills:
+            ctx = QQmlEngine.contextForObject(pill)
+            is_plain, is_undefined = QQmlExpression(
+                ctx, pill, "predTip.contentItem.textFormat === Text.PlainText"
+            ).evaluate()
+            assert is_undefined is False, (
+                "predTip.contentItem could not be resolved -- the tooltip is "
+                "probably back on the ToolTip.text attached property, which "
+                "has no textFormat to pin"
+            )
+            assert is_plain is True, (
+                "the prediction tooltip is not forced to Text.PlainText -- an "
+                "imported pack word containing markup could auto-render as "
+                "HTML and beacon out on hover"
+            )


### PR DESCRIPTION
Five fixes from a security review of the whole tree. Each is small and
independent, and each is its own commit so they can be reverted
separately. Everything here is a fix to existing behaviour, not new
behaviour; `python check.py` passes.

## What is fixed

**1. Typed content was being written to the diagnostic log (critical).**
`main()` pinned the `HybridPredictor` logger to `DEBUG` unconditionally,
and the handlers `_configure_logging` installs carry no level of their
own, so every DEBUG record from the prediction path landed in
`alpha-osk.log`. Those records are the engine's candidate words: the
merged pill row plus the n-gram, PPM and fuzzy shortlists, on every
keystroke. That file is the one `bug_report.yml` asks users to attach.

Reproduced against a verbatim copy of `_configure_logging`:

```
--- contents of alpha-osk.log ---
MERGED result: ['password', 'passphrase', 'pa55word']
N-GRAM preds (next=False): ['mortgage', 'medication', 'divorce']
```

Privacy mode did contain the password case, because it suppresses
`_update_predictions` so nothing is generated to log. Ordinary typing was
not contained. Separately, six INFO records in the n-gram model logged
the literal word behind a right-click pill action, plus a seventh for
auto-rehabilitation; those reached the file regardless.

**2. PowerShell was invoked by bare name on the update trust gate.**
`CreateProcess` searches the CWD before System32, and
`updater._verify_signature` is the whole Authenticode check for
auto-update. A planted `powershell.exe` printing a convincing `Valid|...`
line defeats it. Now resolved from `%SystemRoot%`.

**3. The prediction pill tooltip could render HTML.** The pill's own
`Text` pins `PlainText` because predictions can come from an imported
pack's unsanitised `dictionary.txt`; the tooltip showing the same string
used the `ToolTip.text` attached property, which has no `textFormat`. The
only pill ever truncated is one wider than the whole bar, and the tooltip
shows only when truncated, so the string it renders is exactly the shape
a crafted entry has.

**4. A bad model file could durably break a stated invariant.** `load()`
published `user_vocab` then computed `_user_total` from it, so a
non-numeric count left the poisoned table beside a stale total, with
nothing to recompute it.

**5. NaN survived a round trip into the real model.** `json.load` accepts
bare `NaN`; `json.dumps` defaulted to re-emitting it. One hostile archive
corrupted the user's model permanently. `allow_nan=False` now leaves the
previous good file in place instead.

## Prediction engine

Per CLAUDE.md, calling out that this touches the engine: the n-gram
changes are the seven log statements and the `load()` assignment order.
No scoring, merging, weighting or persistence *content* changes, and no
benchmark figure should move.

## Tests

Every fix has a regression test, and each was verified to fail against
the defect it covers rather than being assumed to. Two are worth naming:

- The log-leak guard is two tests. One states the property end to end (a
  prediction DEBUG record does not reach the file while an INFO record on
  the same logger does, so it cannot pass by writing nothing). The other
  asserts `main()` pins no logger to DEBUG, which is brittle in the usual
  way but is the only one that fails if the line comes back, since
  `main()` builds a QApplication and cannot be executed under test.
- The tooltip test resolves `predTip.contentItem` and fails loudly if the
  code returns to the attached property.

## Deliberately not in this PR

- **The updater's verify-then-launch TOCTOU.** `_verify_signature` reads
  the installer by path, then `_spawn_relauncher` and a callback that
  blocks ~1.8s run, then `_launch_installer` re-opens it for an elevated
  `runas`. A same-user process can swap the file in that window. Fixing
  it properly means holding an exclusive handle across the gap or
  verifying into a location other users cannot write, which is a design
  change rather than a patch. Note the docstring's TOCTOU table currently
  claims the check runs against the same handle we exec, which is not
  accurate.
- **Uncapped collections in the model loader**: `blacklist`,
  `dispreference`, `preferred`, `_blacklist_type_count`, and the
  per-prefix inner dicts of `bigrams`/`trigrams` (only the prefix count is
  capped at 500k). One prefix with millions of successors fits the 50MB
  budget and is then iterated on every keystroke after that word.
- **Unvalidated loaded values** crashing later inside a Qt slot during
  ordinary typing, which is an availability issue on a tool that gets used
  daily.
- **Non-transactional import**: model files are replaced one at a time, so
  a mid-loop failure leaves a mixed config dir. The rescue archive is
  correctly written first, which mitigates it.
- **Windows junctions bypass `_ignore_symlinks`** in pack import
  (`is_symlink()` is false for mount points). I checked for an
  exfiltration path and there is none: export uses non-recursive
  `iterdir()` filtered to four allowed filenames, so copied content never
  reaches an archive.
- No archive member-count cap; `RecursionError` escapes the
  snippets/analytics/dictation loaders.

## Verified clean, for the record

Download host whitelist is `hostname`-based and re-validated after
redirects; signature verification fails closed on every path and pins
`FileVersion` against rollback. No `shell=True` anywhere. All four
xdotool/ydotool sites carrying arbitrary text have the literal `--`. The
Deepgram key is DPAPI-wrapped, created 0600 by `mkstemp` with no
world-readable window, and correctly absent from `_MODEL_FILES`.
Telemetry sends the nine documented integers over https-only with an
empty default endpoint. The worker's D1 statements are parameterised and
every path returns 204. Zip-slip is closed by construction and
`_bounded_copy` caps bytes actually read. `osv-scanner` reports 0 known
vulnerabilities.

## Accessibility

No change to keystroke timing, repeat interval, or visual feedback. The
tooltip keeps its 400ms delay and its trigger condition; only how its
text is rendered changed.
