### PR TITLE
fix(security): pin the installer across the check-then-exec window

### DIFF
--- a/src/updater.py
+++ b/src/updater.py
@@ -44,10 +44,12 @@ Downgrade attack  Strict semver        Older or equal versions are
 Tag confusion    ``releases/latest``   We never trust an arbitrary
                   endpoint             tag — only the repository's own
                                        "latest" pointer.
-TOCTOU on        Atomic temp file      Downloaded to a private temp
-download          (umask 0700)         dir we own, signature check
-                                       runs against the same handle
-                                       we then exec.
+TOCTOU on        Private temp dir      Downloaded to a per-user temp
+download          + a held handle      dir, then held open denying
+                                       writes and deletes from before
+                                       the signature check until after
+                                       the launch, so the bytes we
+                                       verified are the bytes that run.
 Release-notes    Sanitisation          ``_sanitize_notes`` strips
 injection                              control chars + caps length
                                        before reaching QML.
@@ -60,6 +62,8 @@ require a build-pipeline / cert-rotation response.
 
 from __future__ import annotations
 
+import contextlib
+import ctypes
 import json
 import logging
 import os
@@ -69,6 +73,7 @@ import sys
 import tempfile
 import urllib.error
 import urllib.request
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional, Tuple
@@ -527,6 +532,105 @@ def _verify_signature(exe_path: Path, expected_version: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
+_GENERIC_READ = 0x80000000
+_FILE_SHARE_READ = 0x00000001
+_OPEN_EXISTING = 3
+_FILE_ATTRIBUTE_NORMAL = 0x80
+_INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
+
+
+def _open_denying_writes(path: Path) -> Optional[int]:
+    """Open *path* for reading while denying every writer and deleter.
+
+    ``FILE_SHARE_READ`` alone is the whole trick.  Other processes may
+    still *read* the file, which is required (the signature check shells
+    out to PowerShell, which opens it by path, and the image loader opens
+    it again to execute it), but ``FILE_SHARE_WRITE`` and
+    ``FILE_SHARE_DELETE`` are both withheld, so for as long as this
+    handle lives nobody can overwrite the file, rename another file over
+    it, or unlink it.
+
+    Returns the raw handle, or ``None`` if it could not be opened.
+    """
+    if sys.platform != "win32":
+        return None
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    # Pin the signature: an undeclared restype is c_int, which truncates
+    # a 64-bit handle and would make the close silently miss.
+    kernel32.CreateFileW.restype = ctypes.c_void_p
+    kernel32.CreateFileW.argtypes = [
+        ctypes.c_wchar_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+    ]
+    handle = kernel32.CreateFileW(
+        str(path),
+        _GENERIC_READ,
+        _FILE_SHARE_READ,
+        None,
+        _OPEN_EXISTING,
+        _FILE_ATTRIBUTE_NORMAL,
+        None,
+    )
+    if handle == _INVALID_HANDLE_VALUE or handle is None:
+        _logger.error(
+            "Could not pin the installer for execution (error %d)",
+            ctypes.get_last_error(),
+        )
+        return None
+    return int(handle)
+
+
+def _close_handle(handle: int) -> None:
+    """Release a handle from :func:`_open_denying_writes`."""
+    if sys.platform != "win32":
+        return
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
+    kernel32.CloseHandle(ctypes.c_void_p(handle))
+
+
+@contextlib.contextmanager
+def _pinned_for_execution(path: Path) -> Iterator[bool]:
+    """Hold *path* unswappable for the whole check-then-exec sequence.
+
+    Signature verification and the elevated launch each open the
+    installer by path, and between them sit a relauncher spawn and a
+    callback that deliberately blocks for over a second so a toast can
+    paint.  Without this, that gap is a TOCTOU window: a process running
+    as the user can replace the verified installer with its own binary,
+    and ``_launch_installer`` then hands it to ShellExecuteW with
+    ``runas``, so it executes elevated under a UAC prompt the user is
+    expecting.  The EV signature check, which is the one thing standing
+    between a swapped payload and an elevated silent install, ran against
+    bytes that are no longer there.
+
+    Yields True when the file is pinned.  Off Windows it yields True
+    without doing anything: the install path is ShellExecuteW-based and
+    Windows-only, so there is nothing to defend there.
+    """
+    if sys.platform != "win32":
+        yield True
+        return
+
+    handle = _open_denying_writes(path)
+    if handle is None:
+        # Fail closed.  We just wrote this file ourselves, so failing to
+        # reopen it means something already has it locked or it is gone,
+        # and neither is a state to hand to an elevated exec.
+        yield False
+        return
+    try:
+        yield True
+    finally:
+        _close_handle(handle)
+
+
 def _make_private_tempdir() -> Path:
     """Create a tempdir only the current user can read/write."""
     d = Path(tempfile.mkdtemp(prefix="alpha-osk-update-"))
@@ -793,42 +897,55 @@ def download_and_install(
         if not ok:
             return False, "Download failed (see log)"
 
-        if not _verify_signature(dest, info.version):
-            _logger.error("Aborting install — signature verification failed")
-            return False, "Signature check failed (see log)"
+        # Everything from here to the launch runs with the installer
+        # pinned: no other process can overwrite it, rename over it or
+        # delete it. The signature check and the elevated launch each
+        # open it by path, and between them sit the relauncher spawn and
+        # a callback that deliberately blocks for over a second, so
+        # without the pin that gap is a window in which the verified
+        # bytes and the executed bytes can differ. See
+        # _pinned_for_execution.
+        with _pinned_for_execution(dest) as pinned:
+            if not pinned:
+                _logger.error("Aborting install — could not pin the installer")
+                return False, "Could not secure the installer (see log)"
 
-        # Spawn the detached user-IL relauncher BEFORE elevation. This
-        # is the primary mechanism for restarting the OSK after the
-        # install completes; the in-installer Exec explorer.exe trick
-        # is now a fallback (it silently fails on some Windows configs
-        # because of integrity-level rules around elevated parents
-        # spawning user-mode children). See _spawn_relauncher.
-        _spawn_relauncher(info.version)
+            if not _verify_signature(dest, info.version):
+                _logger.error("Aborting install — signature verification failed")
+                return False, "Signature check failed (see log)"
 
-        # Notify the live OSK that the installer is about to launch so
-        # it can flash a toast warning the user. The callback is
-        # expected to block briefly (~1.5 s) so the toast actually
-        # paints before the installer's taskkill arrives. A callback
-        # raise is never fatal — falling through to the install is
-        # better than aborting because a UI signal misfired.
-        if on_installer_launching is not None:
-            try:
-                on_installer_launching(info.version)
-            except Exception as exc:  # noqa: BLE001
-                _logger.warning(
-                    "on_installer_launching callback raised: %s",
-                    exc,
-                )
+            # Spawn the detached user-IL relauncher BEFORE elevation. This
+            # is the primary mechanism for restarting the OSK after the
+            # install completes; the in-installer Exec explorer.exe trick
+            # is now a fallback (it silently fails on some Windows configs
+            # because of integrity-level rules around elevated parents
+            # spawning user-mode children). See _spawn_relauncher.
+            _spawn_relauncher(info.version)
 
-        # /S = NSIS silent install; the installer kills the running
-        # alpha-osk.exe, runs the old uninstaller, and installs the
-        # new build. The relauncher we just spawned will pick up the
-        # new exe and launch it once the install completes.
-        _logger.info("Launching signed installer: %s", dest)
-        ok, err = _launch_installer(dest)
-        if not ok:
-            return False, err
-        return True, ""
+            # Notify the live OSK that the installer is about to launch so
+            # it can flash a toast warning the user. The callback is
+            # expected to block briefly (~1.5 s) so the toast actually
+            # paints before the installer's taskkill arrives. A callback
+            # raise is never fatal — falling through to the install is
+            # better than aborting because a UI signal misfired.
+            if on_installer_launching is not None:
+                try:
+                    on_installer_launching(info.version)
+                except Exception as exc:  # noqa: BLE001
+                    _logger.warning(
+                        "on_installer_launching callback raised: %s",
+                        exc,
+                    )
+
+            # /S = NSIS silent install; the installer kills the running
+            # alpha-osk.exe, runs the old uninstaller, and installs the
+            # new build. The relauncher we just spawned will pick up the
+            # new exe and launch it once the install completes.
+            _logger.info("Launching signed installer: %s", dest)
+            ok, err = _launch_installer(dest)
+            if not ok:
+                return False, err
+            return True, ""
     except Exception as e:  # noqa: BLE001
         _logger.error("Install failed: %s", e)
         return False, f"Install failed: {e}"

--- a/src/updater.py
+++ b/src/updater.py
@@ -907,7 +907,7 @@ def download_and_install(
         # _pinned_for_execution.
         with _pinned_for_execution(dest) as pinned:
             if not pinned:
-                _logger.error("Aborting install — could not pin the installer")
+                _logger.error("Aborting install: could not pin the installer")
                 return False, "Could not secure the installer (see log)"
 
             if not _verify_signature(dest, info.version):

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -9,8 +9,10 @@ is a regression that ships arbitrary code on every user's machine.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -536,6 +538,19 @@ class TestPowerShellSingleQuoteEscaping:
 # ---------------------------------------------------------------------------
 
 
+def _fake_download(url, dest, **kwargs):
+    """Stand in for a successful download by creating the file.
+
+    ``download_and_install`` pins the installer open across the whole
+    check-then-exec sequence, so a stub that reports success without
+    producing a file leaves nothing to pin and the install correctly
+    refuses.  Producing the file is what a real download does anyway.
+    """
+    Path(dest).parent.mkdir(parents=True, exist_ok=True)
+    Path(dest).write_bytes(b"MZ not a real installer")
+    return True
+
+
 class TestDownloadAndInstall:
     def test_aborts_when_signature_check_fails(self, monkeypatch, tmp_path):
         # Stand up a successful download but a failing signature — the
@@ -549,7 +564,7 @@ class TestDownloadAndInstall:
         monkeypatch.setattr(
             updater,
             "_download_with_cap",
-            lambda *a, **kw: True,
+            _fake_download,
         )
         monkeypatch.setattr(updater, "_verify_signature", lambda p, v: False)
         popen_calls = []
@@ -574,7 +589,7 @@ class TestDownloadAndInstall:
         monkeypatch.setattr(
             updater,
             "_download_with_cap",
-            lambda *a, **kw: True,
+            _fake_download,
         )
         monkeypatch.setattr(updater, "_verify_signature", lambda p, v: True)
         launch_calls = []
@@ -599,7 +614,7 @@ class TestDownloadAndInstall:
             asset_name="Alpha-OSK-Setup-1.0.3.exe",
             notes="",
         )
-        monkeypatch.setattr(updater, "_download_with_cap", lambda *a, **kw: True)
+        monkeypatch.setattr(updater, "_download_with_cap", _fake_download)
         monkeypatch.setattr(updater, "_verify_signature", lambda p, v: True)
         # Simulate the user declining the UAC prompt.
         monkeypatch.setattr(
@@ -651,7 +666,7 @@ class TestInstallerLaunchingCallback:
         )
 
     def _stub_happy_path(self, monkeypatch):
-        monkeypatch.setattr(updater, "_download_with_cap", lambda *a, **kw: True)
+        monkeypatch.setattr(updater, "_download_with_cap", _fake_download)
         monkeypatch.setattr(updater, "_verify_signature", lambda p, v: True)
         monkeypatch.setattr(updater, "_spawn_relauncher", lambda v: True)
         monkeypatch.setattr(updater, "_launch_installer", lambda dest: (True, ""))
@@ -686,7 +701,7 @@ class TestInstallerLaunchingCallback:
         assert events[0][1] == "1.2.3"
 
     def test_callback_does_not_fire_when_signature_fails(self, monkeypatch):
-        monkeypatch.setattr(updater, "_download_with_cap", lambda *a, **kw: True)
+        monkeypatch.setattr(updater, "_download_with_cap", _fake_download)
         monkeypatch.setattr(updater, "_verify_signature", lambda p, v: False)
         called: list[str] = []
         monkeypatch.setattr(updater, "_spawn_relauncher", lambda v: True)
@@ -888,3 +903,142 @@ class TestRelauncherSpawnHasNoConsole:
         assert flags & sp.CREATE_NEW_PROCESS_GROUP, (
             "it must stay out of our console group so the installer's taskkill cannot sweep it up"
         )
+
+
+def _swap_succeeds(target: Path) -> bool:
+    """Attempt the swap an attacker running as the user would attempt.
+
+    Writes a payload beside *target* and renames it over the top, which
+    is the realistic vector: it is atomic, needs no write access to the
+    existing file, and leaves the path pointing at different bytes.
+    Returns True if the swap landed.
+    """
+    evil = target.parent / "evil.bin"
+    evil.write_bytes(b"MZ swapped payload")
+    try:
+        os.replace(evil, target)
+        return True
+    except OSError:
+        evil.unlink()
+        return False
+
+
+class TestTheInstallerCannotBeSwappedBetweenCheckAndUse:
+    """The verified bytes must be the executed bytes.
+
+    ``_verify_signature`` and ``_launch_installer`` each open the
+    installer by path, and between them sit ``_spawn_relauncher`` and a
+    callback documented to block for over a second so a toast can paint.
+    Without a pin that gap is a TOCTOU window: a process running as the
+    user replaces the verified installer, and ShellExecuteW hands the
+    replacement to ``runas``, so it runs elevated under a UAC prompt the
+    user is expecting.
+
+    The precondition is same-user code execution, which is why this is
+    escalation rather than initial access -- but escalation is exactly
+    what the EV signature check exists to deny.
+    """
+
+    def _info(self):
+        return UpdateInfo(
+            version="1.0.3",
+            download_url=(
+                "https://github.com/owenpkent/alpha-osk-releases/releases/"
+                "download/v1.0.3/Alpha-OSK-Setup-1.0.3.exe"
+            ),
+            asset_name="Alpha-OSK-Setup-1.0.3.exe",
+            notes="",
+        )
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="pin is a Win32 share-mode")
+    def test_an_unpinned_file_can_be_swapped(self, tmp_path):
+        """The inverse half: without the pin the attack works.
+
+        Without this the blocked-swap assertions below could pass on a
+        filesystem that refuses the rename for some unrelated reason, and
+        would prove nothing about the pin.
+        """
+        target = tmp_path / "Alpha-OSK-Setup-1.0.3.exe"
+        target.write_bytes(b"MZ genuine signed installer")
+
+        assert _swap_succeeds(target) is True
+        assert target.read_bytes() == b"MZ swapped payload"
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="pin is a Win32 share-mode")
+    def test_the_swap_is_blocked_at_both_the_check_and_the_use(self, monkeypatch, tmp_path):
+        """Pinned across the whole sequence, not merely around one call."""
+        monkeypatch.setattr(updater, "_make_private_tempdir", lambda: tmp_path)
+        monkeypatch.setattr(updater, "_download_with_cap", _fake_download)
+        monkeypatch.setattr(updater, "_spawn_relauncher", lambda v: True)
+
+        dest = tmp_path / "Alpha-OSK-Setup-1.0.3.exe"
+        swapped_at = {}
+
+        def fake_verify(path, version):
+            swapped_at["verify"] = _swap_succeeds(dest)
+            return True
+
+        def fake_launch(path):
+            swapped_at["launch"] = _swap_succeeds(dest)
+            return True, ""
+
+        monkeypatch.setattr(updater, "_verify_signature", fake_verify)
+        monkeypatch.setattr(updater, "_launch_installer", fake_launch)
+
+        ok, err = updater.download_and_install(self._info())
+
+        assert ok is True, err
+        assert swapped_at["verify"] is False, "installer was swappable during the check"
+        assert swapped_at["launch"] is False, "installer was swappable at the launch"
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="pin is a Win32 share-mode")
+    def test_the_pin_still_allows_readers(self, tmp_path):
+        """The pin must not break the two things that need the file.
+
+        Signature verification shells out to PowerShell, which opens the
+        installer by path, and the image loader opens it again to execute
+        it.  Denying FILE_SHARE_READ as well would close the window and
+        break the update.
+        """
+        target = tmp_path / "installer.exe"
+        target.write_bytes(b"MZ genuine")
+
+        with updater._pinned_for_execution(target) as pinned:
+            assert pinned is True
+            assert target.read_bytes() == b"MZ genuine"
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="pin is a Win32 share-mode")
+    def test_the_pin_is_released_afterwards(self, tmp_path):
+        """A leaked handle would make the file undeletable for the session."""
+        target = tmp_path / "installer.exe"
+        target.write_bytes(b"MZ genuine")
+
+        with updater._pinned_for_execution(target) as pinned:
+            assert pinned is True
+
+        assert _swap_succeeds(target) is True
+
+    def test_a_file_that_cannot_be_pinned_is_never_launched(self, monkeypatch, tmp_path):
+        """Fail closed.
+
+        We wrote the file ourselves moments earlier, so failing to reopen
+        it means something else holds it or it is gone.  Neither is a
+        state to hand to an elevated exec, so the install aborts rather
+        than proceeding unprotected.
+        """
+        monkeypatch.setattr(updater, "_make_private_tempdir", lambda: tmp_path)
+        monkeypatch.setattr(updater, "_download_with_cap", _fake_download)
+        monkeypatch.setattr(updater, "_verify_signature", lambda p, v: True)
+        monkeypatch.setattr(updater, "_open_denying_writes", lambda p: None)
+        monkeypatch.setattr(sys, "platform", "win32")
+
+        launched = []
+        monkeypatch.setattr(
+            updater, "_launch_installer", lambda d: (launched.append(d), (True, ""))[1]
+        )
+
+        ok, err = updater.download_and_install(self._info())
+
+        assert ok is False
+        assert launched == [], "installer launched despite an unpinnable file"
+        assert "secure" in err.lower(), f"error should name the failed step, got {err!r}"


### PR DESCRIPTION
Closes the TOCTOU in the auto-update path that I deferred out of #80.
Independent of that PR, no overlapping files.

## The problem

`_verify_signature` reads the downloaded installer by path.
`_launch_installer` re-opens it by path for an elevated `ShellExecuteW`
with `runas`. Between them sit `_spawn_relauncher` and a callback the
code documents as blocking ~1.8s so a toast can paint. Nothing held the
file across that gap.

So a process running as the user can rename its own payload over the
installer in that window, and it gets launched elevated under a UAC
prompt the user is expecting, because they asked for the update.

The precondition is same-user code execution, which makes this
escalation rather than initial access. But escalation is exactly what
the EV signature check exists to deny. Everything else on that path is
careful about the bytes in transit: the host whitelist is redirect-safe,
verification fails closed, the version is pinned against rollback. Then
the verified bytes were set down on disk and picked back up by name.

## The fix

`_open_denying_writes` opens the file `GENERIC_READ` + `FILE_SHARE_READ`
only. Other processes can still *read* it, which is required, but
`FILE_SHARE_WRITE` and `FILE_SHARE_DELETE` are withheld, so while the
handle lives nobody can overwrite it, rename over it, or unlink it.
`_pinned_for_execution` holds it from before the check until after the
launch.

I verified the share semantics on Windows before writing any of it,
because the whole approach rests on readers still working:

```
held handle: OK
swap for write      : blocked (Permission denied)
delete              : blocked (used by another process)
powershell read     : OK -> 10.0.26100.8972
execute while held  : OK
```

And the rename-over vector specifically, which is the realistic one
since it is atomic and needs no write access to the existing file:

```
no lock at all          : rename-over SUCCEEDED  <-- swap works
locked FILE_SHARE_READ  : rename-over blocked (Access is denied)
```

**Fails closed.** We wrote the file ourselves moments earlier, so failing
to reopen it means something else holds it or it is gone. Neither is a
state to hand to an elevated exec, so the install aborts. Off Windows the
context manager yields True and does nothing, since the install path is
`ShellExecuteW`-based and Windows-only.

## The docstring was claiming a defence that did not exist

The module's threat-model table said the signature check runs "against
the same handle we then exec". It did not, on either count: two separate
opens, both by path. Corrected in this PR, because a comment asserting a
defence you do not have is worse than no comment, since the next reader
takes it at face value and moves on.

## Tests

They assert the property, not the mechanism. Stubs at *both*
`_verify_signature` and `_launch_installer` attempt the rename-over an
attacker would attempt and record whether it landed, so what is asserted
is that the file is unswappable at both ends of the sequence, rather than
that a handle was opened at some point.

Paired with the inverse (`test_an_unpinned_file_can_be_swapped`), so the
blocked-swap assertions cannot pass on a filesystem that happens to
refuse the rename for an unrelated reason. There is also a test that the
pin still permits readers, since denying `FILE_SHARE_READ` too would
close the window and break updates, and one that the handle is released
afterwards rather than leaking.

Verified the class fails against the unpinned code:

```
E   assert True is False
    assert swapped_at["verify"] is False, "installer was swappable during the check"
```

The Windows-specific ones skip elsewhere; the fail-closed test runs
everywhere.

## One change to existing tests

The `download_and_install` tests stubbed `_download_with_cap` to report
success without producing a file, so there was nothing to pin and the
install correctly refused. They now share a `_fake_download` that creates
it, which is what a real download does and makes those tests exercise
more of the real path than they did.

## Not covered

The pin defends the window inside `download_and_install`. It does not
defend the file between `_download_with_cap` finishing and the pin being
taken, which is a much smaller window but not zero. Closing that fully
means having the download itself hand back an open handle rather than a
path, which is a larger change to `_download_with_cap`'s contract and did
not seem worth bundling here. Worth knowing it exists.

`python check.py` passes.
