### PR TITLE
fix(security): verify the installer's digest once it is pinned

### DIFF
--- a/src/updater.py
+++ b/src/updater.py
@@ -64,6 +64,7 @@ from __future__ import annotations
 
 import contextlib
 import ctypes
+import hashlib
 import json
 import logging
 import os
@@ -323,11 +324,20 @@ def _download_with_cap(
     *,
     timeout: float,
     progress: Optional[ProgressCb],
-) -> bool:
-    """Stream the URL into ``dest`` with a hard byte cap."""
+) -> Optional[str]:
+    """Stream the URL into ``dest`` with a hard byte cap.
+
+    Returns the SHA-256 of the bytes actually written, or ``None`` if the
+    download failed.  The caller re-checks that digest once the file is
+    pinned, which is what closes the sliver between this function
+    releasing its write handle and the pin being taken; see
+    :func:`_pinned_for_execution` for the larger window either side of
+    it.  Returning the digest rather than a bool is the whole point of
+    the contract: only this function ever sees the bytes as they arrive.
+    """
     if not _is_safe_download_url(url):
         _logger.error("Refusing download from disallowed URL: %s", url)
-        return False
+        return None
 
     req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
     try:
@@ -336,7 +346,7 @@ def _download_with_cap(
             final_url = resp.geturl()
             if not _is_safe_download_url(final_url):
                 _logger.error("Refusing post-redirect host: %s", final_url)
-                return False
+                return None
 
             length_hdr = resp.headers.get("Content-Length")
             total = int(length_hdr) if length_hdr and length_hdr.isdigit() else None
@@ -346,10 +356,14 @@ def _download_with_cap(
                     total,
                     _MAX_DOWNLOAD_BYTES,
                 )
-                return False
+                return None
 
             written = 0
             chunk_size = 1 << 16  # 64 KB
+            # Hashed as it streams rather than by re-reading afterwards:
+            # a re-read is a second look at the file, and the gap between
+            # the two looks is exactly the thing being closed.
+            digest = hashlib.sha256()
             with open(dest, "wb") as fh:
                 while True:
                     chunk = resp.read(chunk_size)
@@ -361,14 +375,15 @@ def _download_with_cap(
                             "Aborting download — exceeded cap %d",
                             _MAX_DOWNLOAD_BYTES,
                         )
-                        return False
+                        return None
+                    digest.update(chunk)
                     fh.write(chunk)
                     if progress is not None:
                         progress(written, total)
-        return True
+        return digest.hexdigest()
     except (urllib.error.URLError, TimeoutError, OSError) as e:
         _logger.error("Download failed: %s", e)
-        return False
+        return None
 
 
 def _ps_single_quote_escape(value: str) -> str:
@@ -631,6 +646,25 @@ def _pinned_for_execution(path: Path) -> Iterator[bool]:
         _close_handle(handle)
 
 
+def _file_digest(path: Path) -> Optional[str]:
+    """SHA-256 of *path*, or ``None`` if it could not be read.
+
+    Only meaningful once the file is pinned.  Reading by path is safe
+    there precisely because the pin denies rename-over and delete, so the
+    name cannot have come to mean a different file since; without the pin
+    this would be one more racy look.
+    """
+    digest = hashlib.sha256()
+    try:
+        with open(path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(1 << 16), b""):
+                digest.update(chunk)
+    except OSError as e:
+        _logger.error("Could not re-read the installer: %s", e)
+        return None
+    return digest.hexdigest()
+
+
 def _make_private_tempdir() -> Path:
     """Create a tempdir only the current user can read/write."""
     d = Path(tempfile.mkdtemp(prefix="alpha-osk-update-"))
@@ -888,13 +922,13 @@ def download_and_install(
     dest = work_dir / info.asset_name
 
     try:
-        ok = _download_with_cap(
+        downloaded_digest = _download_with_cap(
             info.download_url,
             dest,
             timeout=timeout,
             progress=progress,
         )
-        if not ok:
+        if downloaded_digest is None:
             return False, "Download failed (see log)"
 
         # Everything from here to the launch runs with the installer
@@ -909,6 +943,25 @@ def download_and_install(
             if not pinned:
                 _logger.error("Aborting install: could not pin the installer")
                 return False, "Could not secure the installer (see log)"
+
+            # The pin closes the window around the check-then-exec
+            # sequence, but it is taken a moment after the download let
+            # go of its own write handle, and that sliver is still a
+            # window. Nothing can prevent a swap inside it, so detect one
+            # instead: the download reported the digest of the bytes it
+            # actually wrote, and the file is immutable from here, so
+            # this comparison cannot itself be raced. A mismatch means
+            # either something replaced the file or the write was
+            # corrupted, and neither is a thing to hand to an elevated
+            # exec.
+            pinned_digest = _file_digest(dest)
+            if pinned_digest != downloaded_digest:
+                _logger.error(
+                    "Aborting install: installer changed after download (expected %s, found %s)",
+                    downloaded_digest,
+                    pinned_digest,
+                )
+                return False, "Installer changed after download (see log)"
 
             if not _verify_signature(dest, info.version):
                 _logger.error("Aborting install — signature verification failed")

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -8,6 +8,8 @@ is a regression that ships arbitrary code on every user's machine.
 
 from __future__ import annotations
 
+import contextlib
+import hashlib
 import json
 import os
 import subprocess
@@ -545,10 +547,15 @@ def _fake_download(url, dest, **kwargs):
     check-then-exec sequence, so a stub that reports success without
     producing a file leaves nothing to pin and the install correctly
     refuses.  Producing the file is what a real download does anyway.
+
+    Returns the SHA-256 of what it wrote, matching the real function's
+    contract: the caller re-checks that digest once the file is pinned,
+    so a stub returning a bool (or the wrong digest) aborts the install.
     """
+    payload = b"MZ not a real installer"
     Path(dest).parent.mkdir(parents=True, exist_ok=True)
-    Path(dest).write_bytes(b"MZ not a real installer")
-    return True
+    Path(dest).write_bytes(payload)
+    return hashlib.sha256(payload).hexdigest()
 
 
 class TestDownloadAndInstall:
@@ -637,7 +644,7 @@ class TestDownloadAndInstall:
         monkeypatch.setattr(
             updater,
             "_download_with_cap",
-            lambda *a, **kw: False,
+            lambda *a, **kw: None,
         )
         verify_calls = []
         monkeypatch.setattr(
@@ -1042,3 +1049,134 @@ class TestTheInstallerCannotBeSwappedBetweenCheckAndUse:
         assert ok is False
         assert launched == [], "installer launched despite an unpinnable file"
         assert "secure" in err.lower(), f"error should name the failed step, got {err!r}"
+
+
+class TestTheDownloadedBytesAreTheBytesThatRun:
+    """The pin has an edge, and the digest covers it.
+
+    ``_pinned_for_execution`` makes the installer unswappable from before
+    the signature check until after the launch.  But it is taken a moment
+    after ``_download_with_cap`` releases its own write handle, and that
+    sliver is still a window.  Nothing can *prevent* a swap inside it, so
+    it is detected instead: the download reports the SHA-256 of the bytes
+    it actually wrote, and the comparison happens once the file is
+    pinned, which is what makes the comparison itself unraceable.
+
+    Unlike the pin, this half is not Windows-specific, so these run
+    everywhere.
+    """
+
+    def _info(self):
+        return UpdateInfo(
+            version="1.0.3",
+            download_url=(
+                "https://github.com/owenpkent/alpha-osk-releases/releases/"
+                "download/v1.0.3/Alpha-OSK-Setup-1.0.3.exe"
+            ),
+            asset_name="Alpha-OSK-Setup-1.0.3.exe",
+            notes="",
+        )
+
+    def _install(self, monkeypatch, tmp_path, launched):
+        monkeypatch.setattr(updater, "_make_private_tempdir", lambda: tmp_path)
+        monkeypatch.setattr(updater, "_download_with_cap", _fake_download)
+        monkeypatch.setattr(updater, "_verify_signature", lambda p, v: True)
+        monkeypatch.setattr(updater, "_spawn_relauncher", lambda v: True)
+
+        def fake_launch(dest):
+            launched.append(dest)
+            return True, ""
+
+        monkeypatch.setattr(updater, "_launch_installer", fake_launch)
+        return updater.download_and_install(self._info())
+
+    def test_a_swap_inside_the_gap_aborts_the_install(self, monkeypatch, tmp_path):
+        """An attacker who wins the race still does not get executed."""
+        real_pin = updater._pinned_for_execution
+
+        @contextlib.contextmanager
+        def swap_then_pin(path):
+            # Exactly the sliver: after the download let go of its write
+            # handle, before the pin is taken.
+            Path(path).write_bytes(b"MZ swapped payload")
+            with real_pin(path) as pinned:
+                yield pinned
+
+        monkeypatch.setattr(updater, "_pinned_for_execution", swap_then_pin)
+
+        launched: list = []
+        ok, err = self._install(monkeypatch, tmp_path, launched)
+
+        assert ok is False
+        assert launched == [], "a swapped installer was launched"
+        assert "changed" in err.lower(), f"error should name the failed step, got {err!r}"
+
+    def test_an_untampered_download_still_installs(self, monkeypatch, tmp_path):
+        """The inverse half.
+
+        A digest check that rejected everything would satisfy the test
+        above and silently break auto-update for everyone.
+        """
+        launched: list = []
+        ok, err = self._install(monkeypatch, tmp_path, launched)
+
+        assert ok is True, err
+        assert len(launched) == 1
+
+    def test_a_truncated_file_is_caught_too(self, monkeypatch, tmp_path):
+        """The same check catches a bad write, not only a hostile one."""
+        real_pin = updater._pinned_for_execution
+
+        @contextlib.contextmanager
+        def truncate_then_pin(path):
+            Path(path).write_bytes(b"MZ not a real install")  # a byte short
+            with real_pin(path) as pinned:
+                yield pinned
+
+        monkeypatch.setattr(updater, "_pinned_for_execution", truncate_then_pin)
+
+        launched: list = []
+        ok, _ = self._install(monkeypatch, tmp_path, launched)
+
+        assert ok is False
+        assert launched == []
+
+    def test_the_digest_is_of_the_bytes_actually_written(self, monkeypatch, tmp_path):
+        """The contract the whole defence rests on.
+
+        Exercises the real ``_download_with_cap`` rather than the stub, so
+        a digest computed over the wrong thing (or a stale re-read) fails
+        here rather than passing everywhere by agreement with the stub.
+        """
+        payload = b"MZ" + bytes(5000) + b"tail"
+        url = (
+            "https://github.com/owenpkent/alpha-osk-releases/releases/"
+            "download/v1.0.3/Alpha-OSK-Setup-1.0.3.exe"
+        )
+
+        resp = mock.MagicMock()
+        resp.__enter__.return_value.read.side_effect = [
+            payload[:1000],
+            payload[1000:],
+            b"",
+        ]
+        resp.__enter__.return_value.geturl.return_value = url
+        resp.__enter__.return_value.headers = {"Content-Length": str(len(payload))}
+
+        monkeypatch.setattr(updater.urllib.request, "urlopen", lambda *a, **kw: resp)
+
+        dest = tmp_path / "Alpha-OSK-Setup-1.0.3.exe"
+        returned = updater._download_with_cap(url, dest, timeout=5, progress=None)
+
+        assert returned == hashlib.sha256(payload).hexdigest()
+        assert returned == hashlib.sha256(dest.read_bytes()).hexdigest()
+
+    def test_a_failed_download_reports_none(self, tmp_path):
+        """None, not False: the contract changed and callers branch on it."""
+        returned = updater._download_with_cap(
+            "https://evil.example.com/Alpha-OSK-Setup-1.0.3.exe",
+            tmp_path / "out.exe",
+            timeout=5,
+            progress=None,
+        )
+        assert returned is None


### PR DESCRIPTION
Closes the gap I named at the bottom of #81. **Stacked on #81** (base is
`fix/updater-toctou`), so review that one first; GitHub will retarget
this to `main` when #81 merges.

## The gap

#81's pin makes the installer unswappable from before the signature
check until after the launch. But it is taken a moment *after*
`_download_with_cap` releases its own write handle, and that sliver is
still a window. Much smaller than the one the pin closed, since nothing
deliberately blocking runs inside it, but not zero.

Nothing can *prevent* a swap there without changing what the download
hands back, so this detects one instead.

## The fix

`_download_with_cap` now returns the SHA-256 of the bytes it actually
wrote rather than a bare bool, hashed as they stream. Hashing by
re-reading the file afterwards would be a second look at it, and the gap
between the two looks is the thing being closed. The caller re-computes
the digest **once the file is pinned** and aborts on a mismatch.

The ordering is what makes it sound: the comparison runs after the pin,
so the file is immutable while it happens and the check itself cannot be
raced. Reading by path is safe there for the same reason, since the pin
denies rename-over and delete, so the name cannot have come to mean a
different file. A swap inside the sliver is therefore always caught, and
forging a match needs a SHA-256 preimage.

It also catches a corrupt or truncated write, which is worth having on
its own: that previously reached the signature check and failed there
with a much less useful error.

Unlike the pin, this half is not Windows-specific.

## Contract change

`_download_with_cap` returns `Optional[str]` instead of `bool`. That
touches two stubs in the existing tests: the failure stub now reports
`None`, and `_fake_download` returns the digest of what it writes.

## Tests

The main one drives a swap into the exact sliver, by wrapping
`_pinned_for_execution` so it replaces the file before delegating to the
real pin, then asserts the install aborts and nothing is launched.

Paired with the inverse (an untampered download still installs), since a
check that rejected everything would satisfy the first test and silently
break auto-update for everyone. The digest contract itself is exercised
against the real `_download_with_cap` with a stubbed `urlopen`, so a
digest computed over the wrong bytes fails there rather than passing
everywhere by agreement with the stub.

Verified both halves fail against the unchecked code:

```
FAILED test_a_swap_inside_the_gap_aborts_the_install
FAILED test_a_truncated_file_is_caught_too
```

`python check.py` passes.
