### PR TITLE
fix(ui): stop the white notch in the window corner on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Alpha-OSK are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **The white notch in a corner of the keyboard on Windows is gone.** It came and went with whatever was behind the window, which is why it read as intermittent. Every transparent window here (the keyboard, the Snippets and Symbols pickers, the Dashboard) rounded its own corners, and on a layered window the pixels outside that arc come back white rather than showing the desktop. On Windows the corners are now left square and the compositor is asked to round them, which it does with proper antialiasing. Windows 10 has no such request to make, so there the corners stay square, like every other window on that desktop. Nothing changes on Linux or macOS.
+
 ## [1.3.0] (2026-09-06)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Owen is a wheelchair user with muscular dystrophy. Typing is hard - be proactive
 ## Key rules (non-obvious, cross-cutting)
 
 - The keyboard must NEVER steal OS focus: `WS_EX_NOACTIVATE` on Windows (`keyboard_app.py::_apply_window_flags` dispatches to `src/platform/windows_window.py::apply_extended_styles`), `WindowDoesNotAcceptFocus` elsewhere. Because our window cannot hold focus, route in-app text entry (prediction-edit popup, snippets editor, any future input slot) through `setEditMode(true)` plus the `editKeyTyped` / `editSpecialPressed` signals, never Qt focus. Set edit mode on open and clear it on close.
-- **Nothing here rounds its own window corners on Windows.** Every window in this app is frameless and `WS_EX_LAYERED`, and the pixels a QML `radius` leaves outside the arc do not composite the desktop on a layered window: they come back white, as a bright notch in one corner. `Main.qml::selfRoundedCorners` squares the background off on Windows and `windows_window.py::_prefer_dwm_rounded_corners` hands the corner to DWM instead. See *Who rounds the window corners*.
+- **No transparent window here rounds its own corners on Windows.** The keyboard, the Snippets and Symbols pickers and the Dashboard are all frameless and `color: "transparent"`, which makes them `WS_EX_LAYERED`, and the pixels a QML `radius` leaves outside the arc do not composite the desktop on a layered window: they come back white, as a bright notch in one corner. `Main.qml::selfRoundedCorners` squares their backgrounds off on Windows and `windows_window.py::_prefer_dwm_rounded_corners` hands the corner to DWM instead. A new floating window with a transparent background must bind to that property and be named in `keyboard_app.py::_wire_floating_windows`. See *Who rounds the window corners*.
 - Sticky-modifier auto-release lives in one place, `KeyboardBridge._release_sticky_modifiers(names=_MODIFIERS, *, keep=())`: every keystroke path (`_press_char`'s edit intercept, chord branch and char-path end; `_release_edit_chord_modifiers`; `pressSpecialKey`) calls it instead of hand-copying the block. `names` restricts which modifiers a call considers (the edit intercept passes only `("shift",)`); `keep` exempts specific active modifiers from an otherwise-eligible release (`pressSpecialKey` passes `keep=("shift", "ctrl")` on `_NAV_KEYS` so Shift/Ctrl survive arrow-key selection). A new keystroke path must call this rather than write its own copy.
 - Linux `LinuxKeySynthesizer.hold_modifier()` MUST skip `win`/`super`: holding Super triggers a WM pointer grab that swallows every click, including clicks on the OSK itself. Do not "fix" it to hold Super. Windows still holds `VK_LWIN`.
 - Pill-facing casing comes only from `KeyboardBridge._display_cased`, which mirrors every uppercase position of the typed prefix onto the pill, unconditionally (including fuzzy/autocorrect candidates). Auto-capitalisation is the "I" family (in the language profile, `language.ENGLISH.always_capitalize`, rather than in `ngram_predictor`) plus taught acronyms (see *Taught acronyms*); do NOT reintroduce the removed three-tier proper-noun auto-cap as a default. Every pill emit site must route through `_display_cased`.
@@ -1979,14 +1979,17 @@ are in *Key rules* at the top of this file.
 
 ## Who rounds the window corners
 
-Every window here is frameless and, on Windows, `WS_EX_LAYERED`. They used
-to round their own corners with a `radius` on the QML background rectangle,
-which leaves the pixels outside the arc unpainted, and **on a layered window
-those do not composite the desktop the way a transparent pixel should: they
-come back white**. What the user sees is a small bright notch biting into a
-corner of the keyboard, appearing and disappearing depending on what happens
-to be behind it, which is why it looks intermittent and unrelated to
-anything.
+Every window here is frameless, and four of them (the keyboard, the Snippets
+and Symbols pickers, and the Dashboard) are `color: "transparent"`, which on
+Windows makes them `WS_EX_LAYERED`. They used to round their own corners
+with a `radius` on the QML background rectangle, which leaves the pixels
+outside the arc unpainted, and **on a layered window those do not composite
+the desktop the way a transparent pixel should: they come back white**. What
+the user sees is a small bright notch biting into a corner of the keyboard,
+appearing and disappearing depending on what happens to be behind it, which
+is why it looks intermittent and unrelated to anything. (Settings and Help
+are opaque `#1e1e1e` windows with a rounded panel inside; their corners show
+the window's own dark colour rather than white, so they are left alone.)
 
 Measured on the real `Main.qml`, against a magenta backdrop placed behind
 all four corners:
@@ -2006,31 +2009,51 @@ title bar and the shadow, and
 `DWMWA_WINDOW_CORNER_PREFERENCE` to `DWMWCP_ROUND` so the compositor masks
 an opaque window, which it antialiases properly.
 
-Four things follow:
+Six things follow:
 
 - **The title bar's radius has to follow the background's.** Rounding it
   while the background behind it is square swaps the notch for a lighter
   wedge in each top corner, since what shows through is then the background
-  rather than the desktop.
-- **The two floating windows are the same shape and needed the same fix.**
-  `SnippetsWindow` and `SymbolsWindow` are both `color: "transparent"` with
-  a radius-8 background, so a fix reaching only the keyboard would have left
-  the notch on the two windows that float over whatever the user is typing
-  into. They take `selfRoundedCorners` as a required property from
-  `Main.qml` rather than each reading `Qt.platform.os`, so the rule is
-  stated once.
+  rather than the desktop. The Dashboard's header is the same case.
+- **The three floating windows are the same shape and needed the same fix.**
+  `SnippetsWindow`, `SymbolsWindow` and the Dashboard (`vizWindow`, whose
+  `ModelVisualization` panel draws the background) are all transparent with
+  a rounded background, so a fix reaching only the keyboard would have left
+  the notch on the windows that float over whatever the user is typing into.
+  The Dashboard was in fact missed by the first version. They take
+  `selfRoundedCorners` as a required property from `Main.qml` rather than
+  each reading `Qt.platform.os`, so the rule is stated once, and
+  `keyboard_app.py::_wire_floating_windows` names all three so the DWM call
+  reaches them once they are shown. The Dashboard gets only that call: it is
+  allowed to take focus (it has no keys on it), so it must not go through
+  `apply_extended_styles` and pick up `WS_EX_NOACTIVATE` with the corner.
+- **The DWM call runs before the style writes, not after.** Each of those
+  returns early on failure and is logged, and the corner needs nothing they
+  compute, so it must not be lost with them.
 - **The DWM call is best-effort and must stay that way.**
   `DWMWA_WINDOW_CORNER_PREFERENCE` is Windows 11 and later; on Windows 10 it
   fails and the window keeps the square corners QML gave it, which is what
   every other window on that desktop looks like. A window that fails to
   round is cosmetic, never a reason to fail startup.
+- **The screenshot script takes the rounding back.** `Qt.platform.os` still
+  reads `"windows"` under the offscreen plugin, but there is no compositor
+  behind it, so `scripts/capture_screenshots.py` sets `selfRoundedCorners`
+  back to true after loading `Main.qml` or every screenshot regenerated on
+  the Windows dev machine comes out with hard square corners. That is why
+  the property is not `readonly`.
 - **The offscreen render was correct the whole time the bug was on screen.**
   `assets/screenshots/dark-theme-keyboard.png` had a properly antialiased
   alpha-0 corner while the live window showed the notch, so a test that
   rendered the corner and looked at it would have passed against the bug.
   `tests/test_window_corners.py` therefore pins the checkable half (which
-  side is asked to round, that all three windows agree, and that the DWM
-  call cannot raise) and says in its docstring why it cannot pin the rest.
+  side is asked to round, that every transparent window agrees, what the DWM
+  call asks for and that it cannot raise) and says in its docstring why it
+  cannot pin the rest.
+
+Not yet checked on a real desktop: the background keeps its 1 px theme
+border while its radius is 0, so along the corner arc DWM's mask clips that
+border and draws its own. If that reads wrong on a light theme, the answer
+is `DWMWA_BORDER_COLOR`, not a radius on the QML side.
 
 ## Title-bar window menu, and click-free Move
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Owen is a wheelchair user with muscular dystrophy. Typing is hard - be proactive
 ## Key rules (non-obvious, cross-cutting)
 
 - The keyboard must NEVER steal OS focus: `WS_EX_NOACTIVATE` on Windows (`keyboard_app.py::_apply_window_flags` dispatches to `src/platform/windows_window.py::apply_extended_styles`), `WindowDoesNotAcceptFocus` elsewhere. Because our window cannot hold focus, route in-app text entry (prediction-edit popup, snippets editor, any future input slot) through `setEditMode(true)` plus the `editKeyTyped` / `editSpecialPressed` signals, never Qt focus. Set edit mode on open and clear it on close.
+- **Nothing here rounds its own window corners on Windows.** Every window in this app is frameless and `WS_EX_LAYERED`, and the pixels a QML `radius` leaves outside the arc do not composite the desktop on a layered window: they come back white, as a bright notch in one corner. `Main.qml::selfRoundedCorners` squares the background off on Windows and `windows_window.py::_prefer_dwm_rounded_corners` hands the corner to DWM instead. See *Who rounds the window corners*.
 - Sticky-modifier auto-release lives in one place, `KeyboardBridge._release_sticky_modifiers(names=_MODIFIERS, *, keep=())`: every keystroke path (`_press_char`'s edit intercept, chord branch and char-path end; `_release_edit_chord_modifiers`; `pressSpecialKey`) calls it instead of hand-copying the block. `names` restricts which modifiers a call considers (the edit intercept passes only `("shift",)`); `keep` exempts specific active modifiers from an otherwise-eligible release (`pressSpecialKey` passes `keep=("shift", "ctrl")` on `_NAV_KEYS` so Shift/Ctrl survive arrow-key selection). A new keystroke path must call this rather than write its own copy.
 - Linux `LinuxKeySynthesizer.hold_modifier()` MUST skip `win`/`super`: holding Super triggers a WM pointer grab that swallows every click, including clicks on the OSK itself. Do not "fix" it to hold Super. Windows still holds `VK_LWIN`.
 - Pill-facing casing comes only from `KeyboardBridge._display_cased`, which mirrors every uppercase position of the typed prefix onto the pill, unconditionally (including fuzzy/autocorrect candidates). Auto-capitalisation is the "I" family (in the language profile, `language.ENGLISH.always_capitalize`, rather than in `ngram_predictor`) plus taught acronyms (see *Taught acronyms*); do NOT reintroduce the removed three-tier proper-noun auto-cap as a default. Every pill emit site must route through `_display_cased`.
@@ -1975,6 +1976,61 @@ are in *Key rules* at the top of this file.
 - **Games need a held key, not a zero-gap tap.** Games read the keyboard by *polling* state once per render frame (DirectInput / Raw Input / `GetAsyncKeyState`), so a key-down+key-up injected in one `SendInput` batch can land entirely between two polls and be missed: the keystroke does nothing in-game even though it works everywhere else. Auto game-compat fixes this: when `_window_is_game(hwnd)` is true, `_game_auto_active` flips on (set in the same 250 ms foreground poll as compat auto-detect) and single keys are sent with `hold_seconds = _GAME_KEY_HOLD_SECONDS` (50 ms). `WindowsKeySynthesizer.send_key` then splits the injection into a down-batch, a real `time.sleep`, and an up-batch (modifiers wrap the held key). Non-game keystrokes keep the zero-latency atomic path. `_window_is_game` uses three signals (`keyboard_bridge.py`): (1) the owning-process exe is in `_GAME_PROCESS_NAMES` (seeded with the Age of Empires family plus `unrealeditor.exe`; extend like `_COMPAT_PROCESS_NAMES`), which catches games even in windowed mode; (2) the exe ends with one of `_GAME_EXE_SUFFIXES`, which matches a whole **engine family** rather than a title: every packaged Unreal game ships a `<Project>-Win64-Shipping.exe`, so one suffix covers any UE title, windowed included, without anyone having to add it to a list; (3) a **borderless-fullscreen heuristic** (`_window_is_borderless_fullscreen`: window rect covers the whole monitor *and* the window has no `WS_CAPTION`) as a zero-config catch-all for unlisted games. The heuristic is deliberately skipped for exes in `_COMPAT_PROCESS_NAMES` (IDEs / remote-desktop clients), which are sometimes run fullscreen and must not get the typing-lag hold. Requiring "no caption" excludes normal maximized windows (which keep their title bar); the remaining false positives (fullscreen video players, slideshows) are harmless because a 50 ms hold doesn't hurt there. **The Unreal Editor is listed deliberately, editor and all.** Play-in-editor polls input exactly like a shipped game and the editor runs windowed, so neither of the other two signals reaches it. The cost is that the editor's own text fields (asset rename, content-browser search) take the 50 ms hold too, which is latency rather than lost input, while without it viewport and PIE keys are dropped entirely. Any future entry that is an authoring tool rather than a game owes the same trade in the same direction, and it is only worth taking where the tool polls input. Coverage for both new signals is in `tests/test_keyboard_bridge.py::TestGameKeyHold` (`test_unreal_editor_windowed_is_game`, `test_unreal_shipping_suffix_is_game`), each with the fullscreen heuristic stubbed **off** so it cannot be what makes them pass. This is unrelated to UIAccess: a signed Program-Files install still hit it because the keystrokes *reach* the game, they're just too brief to be polled.
 - **`pressKey` lowercases its input** - use `pressKeyLiteral` when QML already resolved the final character (right-click shifted variant, etc.).
 - **QML `Text` defaults to `AutoText`, which sniffs the string for HTML and can trigger an outbound request just from being displayed.** Any `Text` rendering a value that ultimately came from imported or otherwise untrusted data (a vocabulary pack's `name`/`description`, anything read from a file the user picked) must set `textFormat: Text.PlainText` explicitly, or an `<img src=...>` planted in that string makes Qt fetch it the moment the Settings page renders. 23 `Text` elements across 7 QML files (`Main.qml`, `UnifiedSettingsPanel.qml`, `DebugPanel.qml`, `AnalyticsDashboard.qml`, `ModelVisualization.qml`, `KeyButton.qml`, `SettingsToggle.qml`) now set it explicitly; new `Text` elements displaying untrusted strings must too. **Known gap**: the attached-property `ToolTip.text` idiom has no `textFormat` to set, so a tooltip built from untrusted text is not covered.
+
+## Who rounds the window corners
+
+Every window here is frameless and, on Windows, `WS_EX_LAYERED`. They used
+to round their own corners with a `radius` on the QML background rectangle,
+which leaves the pixels outside the arc unpainted, and **on a layered window
+those do not composite the desktop the way a transparent pixel should: they
+come back white**. What the user sees is a small bright notch biting into a
+corner of the keyboard, appearing and disappearing depending on what happens
+to be behind it, which is why it looks intermittent and unrelated to
+anything.
+
+Measured on the real `Main.qml`, against a magenta backdrop placed behind
+all four corners:
+
+| configuration | corner pixel |
+|---|---|
+| radius 10, Windows 11 default rounding | `#ffffff` |
+| radius 10, `DWMWCP_DONOTROUND` | `#ffffff` |
+| radius 0, `DWMWCP_ROUND` | the backdrop, correctly |
+
+**Turning Windows' own rounding off fixes nothing, and that is the part
+worth remembering**: the notch is the unpainted region, not the rounding.
+The fix is to leave nothing unpainted. `Main.qml::selfRoundedCorners` is
+false on Windows, which takes `windowRadius` to 0 for the background, the
+title bar and the shadow, and
+`windows_window.py::_prefer_dwm_rounded_corners` sets
+`DWMWA_WINDOW_CORNER_PREFERENCE` to `DWMWCP_ROUND` so the compositor masks
+an opaque window, which it antialiases properly.
+
+Four things follow:
+
+- **The title bar's radius has to follow the background's.** Rounding it
+  while the background behind it is square swaps the notch for a lighter
+  wedge in each top corner, since what shows through is then the background
+  rather than the desktop.
+- **The two floating windows are the same shape and needed the same fix.**
+  `SnippetsWindow` and `SymbolsWindow` are both `color: "transparent"` with
+  a radius-8 background, so a fix reaching only the keyboard would have left
+  the notch on the two windows that float over whatever the user is typing
+  into. They take `selfRoundedCorners` as a required property from
+  `Main.qml` rather than each reading `Qt.platform.os`, so the rule is
+  stated once.
+- **The DWM call is best-effort and must stay that way.**
+  `DWMWA_WINDOW_CORNER_PREFERENCE` is Windows 11 and later; on Windows 10 it
+  fails and the window keeps the square corners QML gave it, which is what
+  every other window on that desktop looks like. A window that fails to
+  round is cosmetic, never a reason to fail startup.
+- **The offscreen render was correct the whole time the bug was on screen.**
+  `assets/screenshots/dark-theme-keyboard.png` had a properly antialiased
+  alpha-0 corner while the live window showed the notch, so a test that
+  rendered the corner and looked at it would have passed against the bug.
+  `tests/test_window_corners.py` therefore pins the checkable half (which
+  side is asked to round, that all three windows agree, and that the DWM
+  call cannot raise) and says in its docstring why it cannot pin the rest.
 
 ## Title-bar window menu, and click-free Move
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -1164,12 +1164,36 @@ Window {
         }
     }
 
+    // Who rounds the window's corners.
+    //
+    // Everywhere but Windows we round them ourselves, with a `radius` on the
+    // background below.  On Windows that is exactly what produced the white
+    // notch in the top-left corner: every window here is frameless and
+    // WS_EX_LAYERED, and the pixels a `radius` leaves outside the arc do not
+    // composite the desktop on a layered window, they come back white.
+    //
+    // Measured against a magenta backdrop behind all four corners: with
+    // radius 10 the corner pixel is #ffffff whether Windows' own rounding is
+    // on or off, and with radius 0 plus DWMWCP_ROUND it is the backdrop.  So
+    // the notch is the unpainted region rather than the rounding, and the
+    // fix is to leave nothing unpainted: square the background off and let
+    // DWM mask an opaque window, which it antialiases properly.
+    // `windows_window.py::_prefer_dwm_rounded_corners` is the other half.
+    //
+    // On Windows 10 that DWM call fails and the corners stay square, which
+    // is what every other window on that desktop looks like.
+    readonly property bool selfRoundedCorners: Qt.platform.os !== "windows"
+    readonly property real windowRadius: selfRoundedCorners ? 10 : 0
+
     // Main background — uses Qt.rgba so only the background becomes transparent
     // while keys and text remain fully opaque
     Rectangle {
         id: background
+        // Lets the corner test measure the rendered radius rather than
+        // re-reading the property that sets it.
+        objectName: "windowBackground"
         anchors.fill: parent
-        radius: 10
+        radius: root.windowRadius
         color: Qt.rgba(root.themeBackground.r, root.themeBackground.g, root.themeBackground.b, root.windowOpacity)
         border.color: Qt.rgba(root.themeBorder.r, root.themeBorder.g, root.themeBorder.b, root.windowOpacity)
         border.width: 1
@@ -1180,7 +1204,7 @@ Window {
         Rectangle {
             anchors.fill: parent
             anchors.margins: -1
-            radius: 11
+            radius: root.windowRadius > 0 ? root.windowRadius + 1 : 0
             color: "transparent"
             border.color: Qt.rgba(0, 0, 0, 0.5)
             border.width: 1
@@ -1201,7 +1225,10 @@ Window {
             height: 48
             property color baseColor: Qt.darker(root.themeBackground, 1.1)
             color: Qt.rgba(baseColor.r, baseColor.g, baseColor.b, root.windowOpacity)
-            radius: 10
+            // Follows the background: rounding this while the background
+            // behind it is square would show a lighter wedge in each top
+            // corner instead of a notch.
+            radius: root.windowRadius
 
             // Only round top corners
             Rectangle {
@@ -3682,6 +3709,7 @@ Window {
         // rather than a Popup, the three-view split, and why a tap copies
         // to the clipboard rather than types.
         Comp.SnippetsWindow {
+            selfRoundedCorners: root.selfRoundedCorners
             id: snippetsWindow
             applyEditChord: root.applyEditChord
             clampedWindowPos: root.clampedWindowPos
@@ -3712,6 +3740,7 @@ Window {
         // itself and the full rationale -- it deliberately shares its
         // shell with the Snippets window above.
         Comp.SymbolsWindow {
+            selfRoundedCorners: root.selfRoundedCorners
             id: symbolsWindow
             clampedWindowPos: root.clampedWindowPos
             themeAccent: root.themeAccent

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -1168,21 +1168,20 @@ Window {
     //
     // Everywhere but Windows we round them ourselves, with a `radius` on the
     // background below.  On Windows that is exactly what produced the white
-    // notch in the top-left corner: every window here is frameless and
-    // WS_EX_LAYERED, and the pixels a `radius` leaves outside the arc do not
-    // composite the desktop on a layered window, they come back white.
+    // notch in a corner: this window is transparent and therefore
+    // WS_EX_LAYERED, and the pixels a `radius` leaves outside the arc come
+    // back white on a layered window rather than showing the desktop.  So
+    // the background is squared off there and DWM masks the corner instead
+    // (`windows_window.py::_prefer_dwm_rounded_corners`).  The measurements
+    // and the reasoning are under "Who rounds the window corners" in
+    // CLAUDE.md.  The two pickers and the dashboard bind to this rather than
+    // reading Qt.platform.os themselves, so the rule is stated once.
     //
-    // Measured against a magenta backdrop behind all four corners: with
-    // radius 10 the corner pixel is #ffffff whether Windows' own rounding is
-    // on or off, and with radius 0 plus DWMWCP_ROUND it is the backdrop.  So
-    // the notch is the unpainted region rather than the rounding, and the
-    // fix is to leave nothing unpainted: square the background off and let
-    // DWM mask an opaque window, which it antialiases properly.
-    // `windows_window.py::_prefer_dwm_rounded_corners` is the other half.
-    //
-    // On Windows 10 that DWM call fails and the corners stay square, which
-    // is what every other window on that desktop looks like.
-    readonly property bool selfRoundedCorners: Qt.platform.os !== "windows"
+    // Not readonly, for one caller: `scripts/capture_screenshots.py` renders
+    // through the offscreen plugin, where Qt.platform.os still reads
+    // "windows" but there is no compositor to round anything, so it sets
+    // this back to true to keep the screenshots' corners.
+    property bool selfRoundedCorners: Qt.platform.os !== "windows"
     readonly property real windowRadius: selfRoundedCorners ? 10 : 0
 
     // Main background — uses Qt.rgba so only the background becomes transparent
@@ -1204,7 +1203,7 @@ Window {
         Rectangle {
             anchors.fill: parent
             anchors.margins: -1
-            radius: root.windowRadius > 0 ? root.windowRadius + 1 : 0
+            radius: root.selfRoundedCorners ? root.windowRadius + 1 : 0
             color: "transparent"
             border.color: Qt.rgba(0, 0, 0, 0.5)
             border.width: 1
@@ -1230,8 +1229,10 @@ Window {
             // corner instead of a notch.
             radius: root.windowRadius
 
-            // Only round top corners
+            // Only round top corners.  Nothing to square off when the bar
+            // is already square.
             Rectangle {
+                visible: root.selfRoundedCorners
                 anchors.bottom: parent.bottom
                 anchors.left: parent.left
                 anchors.right: parent.right
@@ -3709,8 +3710,8 @@ Window {
         // rather than a Popup, the three-view split, and why a tap copies
         // to the clipboard rather than types.
         Comp.SnippetsWindow {
-            selfRoundedCorners: root.selfRoundedCorners
             id: snippetsWindow
+            selfRoundedCorners: root.selfRoundedCorners
             applyEditChord: root.applyEditChord
             clampedWindowPos: root.clampedWindowPos
             inkOn: root.inkOn
@@ -3740,8 +3741,8 @@ Window {
         // itself and the full rationale -- it deliberately shares its
         // shell with the Snippets window above.
         Comp.SymbolsWindow {
-            selfRoundedCorners: root.selfRoundedCorners
             id: symbolsWindow
+            selfRoundedCorners: root.selfRoundedCorners
             clampedWindowPos: root.clampedWindowPos
             themeAccent: root.themeAccent
             themeBackground: root.themeBackground
@@ -4903,6 +4904,9 @@ Window {
     // ===== Model Visualization Window =====
     Window {
         id: vizWindow
+        // Found by name from keyboard_app.py::_wire_floating_windows, which
+        // hands its corners to DWM once it is shown (see selfRoundedCorners).
+        objectName: "vizWindow"
         title: "Your Language Model"
         visible: root.showVisualization
         width: 720
@@ -4925,6 +4929,8 @@ Window {
 
         Comp.ModelVisualization {
             id: vizContent
+            objectName: "vizContent"
+            selfRoundedCorners: root.selfRoundedCorners
             anchors.fill: parent
             onCloseRequested: root.showVisualization = false
         }

--- a/qml/components/ModelVisualization.qml
+++ b/qml/components/ModelVisualization.qml
@@ -8,6 +8,12 @@ Item {
 
     signal closeRequested()
 
+    // Whether this panel rounds the window's corners itself.  Bound from
+    // Main.qml's `selfRoundedCorners`, which carries the reasoning: the
+    // window behind this is transparent, and on Windows a `radius` on a
+    // layered window leaves corner pixels that come back white.
+    required property bool selfRoundedCorners
+
     property var vizData: null
     property int currentTab: 0
 
@@ -71,7 +77,7 @@ Item {
     Rectangle {
         anchors.fill: parent
         color: "#1a1a2e"
-        radius: 10
+        radius: vizPanel.selfRoundedCorners ? 10 : 0
         border.color: "#444"
         border.width: 1
         clip: true
@@ -86,10 +92,12 @@ Item {
                 Layout.fillWidth: true
                 Layout.preferredHeight: 42
                 color: "#16213e"
-                radius: 10
+                // Follows the background, as the keyboard's title bar does.
+                radius: vizPanel.selfRoundedCorners ? 10 : 0
 
                 // Square off bottom corners
                 Rectangle {
+                    visible: vizPanel.selfRoundedCorners
                     anchors.bottom: parent.bottom
                     anchors.left: parent.left
                     anchors.right: parent.right

--- a/qml/components/SnippetsWindow.qml
+++ b/qml/components/SnippetsWindow.qml
@@ -27,10 +27,7 @@ Window {
     // toasts (which must stay on the keyboard window, see below) can
     // still fire from here.
     // Whether this window rounds its own corners, or leaves them to the
-    // compositor.  Bound from Main.qml's `selfRoundedCorners`, which carries
-    // the reasoning: on Windows a `radius` on a layered window's background
-    // leaves pixels that come back white instead of transparent, so the
-    // background is squared off there and DWM masks the corner instead.
+    // compositor.  Bound from Main.qml's `selfRoundedCorners`; see there.
     required property bool selfRoundedCorners
     required property var applyEditChord
     required property var clampedWindowPos

--- a/qml/components/SnippetsWindow.qml
+++ b/qml/components/SnippetsWindow.qml
@@ -26,6 +26,12 @@ Window {
     // required properties bound in Main.qml, and signals so the
     // toasts (which must stay on the keyboard window, see below) can
     // still fire from here.
+    // Whether this window rounds its own corners, or leaves them to the
+    // compositor.  Bound from Main.qml's `selfRoundedCorners`, which carries
+    // the reasoning: on Windows a `radius` on a layered window's background
+    // leaves pixels that come back white instead of transparent, so the
+    // background is squared off there and DWM masks the corner instead.
+    required property bool selfRoundedCorners
     required property var applyEditChord
     required property var clampedWindowPos
     required property var inkOn
@@ -456,7 +462,7 @@ Window {
         color: themeBackground
         border.color: themeAccent
         border.width: 1
-        radius: 8
+        radius: snippetsWindow.selfRoundedCorners ? 8 : 0
     }
 
     ColumnLayout {

--- a/qml/components/SymbolsWindow.qml
+++ b/qml/components/SymbolsWindow.qml
@@ -26,10 +26,7 @@ Window {
     // problem toast (which must stay on the keyboard window) can
     // still fire from here.
     // Whether this window rounds its own corners, or leaves them to the
-    // compositor.  Bound from Main.qml's `selfRoundedCorners`, which carries
-    // the reasoning: on Windows a `radius` on a layered window's background
-    // leaves pixels that come back white instead of transparent, so the
-    // background is squared off there and DWM masks the corner instead.
+    // compositor.  Bound from Main.qml's `selfRoundedCorners`; see there.
     required property bool selfRoundedCorners
     required property var clampedWindowPos
     required property color themeAccent

--- a/qml/components/SymbolsWindow.qml
+++ b/qml/components/SymbolsWindow.qml
@@ -25,6 +25,12 @@ Window {
     // required properties bound in Main.qml, and a signal so the
     // problem toast (which must stay on the keyboard window) can
     // still fire from here.
+    // Whether this window rounds its own corners, or leaves them to the
+    // compositor.  Bound from Main.qml's `selfRoundedCorners`, which carries
+    // the reasoning: on Windows a `radius` on a layered window's background
+    // leaves pixels that come back white instead of transparent, so the
+    // background is squared off there and DWM masks the corner instead.
+    required property bool selfRoundedCorners
     required property var clampedWindowPos
     required property color themeAccent
     required property color themeBackground
@@ -197,7 +203,7 @@ Window {
     Rectangle {
         anchors.fill: parent
         color: themeBackground
-        radius: 8
+        radius: symbolsWindow.selfRoundedCorners ? 8 : 0
         border.color: themeAccent
         border.width: 1
 

--- a/scripts/capture_screenshots.py
+++ b/scripts/capture_screenshots.py
@@ -249,6 +249,13 @@ def main() -> int:
         root = engine.rootObjects()[0]
         _settle(800)
 
+        # On Windows the live window leaves its corners to DWM and squares
+        # its own background off (see `selfRoundedCorners` in Main.qml),
+        # but there is no compositor behind the offscreen plugin, so the
+        # rounding has to come from the QML side here or every screenshot
+        # gets hard square corners.
+        root.setProperty("selfRoundedCorners", True)
+
         # Every panel on, so the hero shot shows what the keyboard can be
         # rather than what it is on a fresh install.
         root.setProperty("showFunctionRow", True)

--- a/src/keyboard_app.py
+++ b/src/keyboard_app.py
@@ -258,19 +258,24 @@ def _apply_window_flags(root: QWindow) -> None:
 
 
 def _wire_floating_windows(root: QWindow) -> None:
-    """Apply OSK focus-suppression to the floating Snippets and Symbols windows.
+    """Apply the Win32 styling the floating windows need once they are shown.
 
-    Both are separate top-level ``Window``s declared in Main.qml
-    (objectNames ``snippetsWindow`` and ``symbolsWindow``) so they can
-    float anywhere on the desktop, outside the keyboard. Like the main
-    window they must never steal focus from the app the user is typing
-    into, so on Windows each needs ``WS_EX_NOACTIVATE`` applied via Win32,
-    since the Qt ``WindowDoesNotAcceptFocus`` flag alone doesn't stop
-    click-activation there. The native handle only exists once a window
-    has been shown, so we (re)apply on every visibility change rather
-    than once at startup. A missing window is skipped rather than
-    aborting the rest: one unstyled picker is a smaller problem than
-    both of them going unwired.
+    Three separate top-level ``Window``s are declared in Main.qml so they
+    can float anywhere on the desktop, outside the keyboard: the Snippets
+    and Symbols pickers (objectNames ``snippetsWindow`` and
+    ``symbolsWindow``) and the Dashboard (``vizWindow``). The two pickers
+    must never steal focus from the app the user is typing into, so on
+    Windows each needs ``WS_EX_NOACTIVATE`` applied via Win32, since the
+    Qt ``WindowDoesNotAcceptFocus`` flag alone doesn't stop
+    click-activation there. The Dashboard is allowed to take focus (it
+    has no keys on it) and gets only the corner-rounding half, which all
+    three transparent windows need for the reason under *Who rounds the
+    window corners* in CLAUDE.md.
+
+    The native handle only exists once a window has been shown, so we
+    (re)apply on every visibility change rather than once at startup. A
+    missing window is skipped rather than aborting the rest: one unstyled
+    window is a smaller problem than all of them going unwired.
 
     No-op on non-Windows (the Qt flag is sufficient on X11/Wayland, and
     macOS uses the Accessory activation policy applied app-wide). Silent
@@ -282,28 +287,37 @@ def _wire_floating_windows(root: QWindow) -> None:
     try:
         from PySide6.QtCore import QObject
 
-        for name in ("snippetsWindow", "symbolsWindow"):
+        wiring: dict[str, Callable[[QWindow], None]] = {
+            "snippetsWindow": windows_window.apply_extended_styles,
+            "symbolsWindow": windows_window.apply_extended_styles,
+            "vizWindow": windows_window.prefer_dwm_rounded_corners,
+        }
+        for name, style in wiring.items():
             win = root.findChild(QObject, name)
             if win is None:
-                _logger.warning("%s not found; skipping focus-suppression", name)
+                _logger.warning("%s not found; skipping its window styling", name)
                 continue
             # findChild() is typed to return a bare QObject; the QML side
             # only ever names real top-level Window items here, so this is
             # always a QWindow at runtime.
             win_window = cast(QWindow, win)
 
-            # Bound as a default argument rather than closed over: the loop
-            # variable is rebound on the next pass, so a plain closure would
-            # leave every handler applying styles to the last window found.
-            def _apply(target: QWindow = win_window, label: str = name) -> None:
+            # Bound as default arguments rather than closed over: the loop
+            # variables are rebound on the next pass, so a plain closure
+            # would leave every handler styling the last window found.
+            def _apply(
+                target: QWindow = win_window,
+                label: str = name,
+                apply_style: Callable[[QWindow], None] = style,
+            ) -> None:
                 try:
                     if target.property("visible"):
-                        windows_window.apply_extended_styles(target)
+                        apply_style(target)
                 except Exception as exc:  # pragma: no cover, defensive
                     _logger.debug("%s style apply failed: %s", label, exc)
 
             win_window.visibleChanged.connect(_apply)
-            _logger.info("Wired %s focus-suppression", name)
+            _logger.info("Wired %s window styling", name)
     except Exception as exc:  # pragma: no cover, defensive
         _logger.warning("Failed to wire the floating windows: %s", exc)
 

--- a/src/platform/windows_window.py
+++ b/src/platform/windows_window.py
@@ -289,9 +289,84 @@ def apply_extended_styles(root: QWindow, *, taskbar_button: bool = False) -> Non
                 kernel32.GetLastError(),
             )
 
+        _prefer_dwm_rounded_corners(hwnd)
+
         _logger.info("Applied WS_EX_NOACTIVATE and placed the window in the topmost band")
     except Exception as e:
         _logger.warning("Failed to apply Windows extended styles: %s", e)
+
+
+def _prefer_dwm_rounded_corners(hwnd: object) -> None:
+    """Ask Windows to round this window's corners, rather than doing it here.
+
+    Every window in this app is frameless *and* ``WS_EX_LAYERED``, and it
+    used to draw its own rounded corner as a ``radius`` on the QML
+    background rectangle.  That leaves the pixels outside the arc unpainted,
+    and on a layered window those do not composite the desktop the way a
+    transparent pixel should: they come back **white**.  What the user sees
+    is a small bright notch biting into one corner of the keyboard, whose
+    visibility depends on what happens to be behind it.
+
+    Measured against a magenta backdrop placed behind all four corners, with
+    the window otherwise configured exactly as it ships:
+
+    ==========================================  ======================
+    configuration                               corner pixel
+    ==========================================  ======================
+    radius 10, DWM default                      ``#ffffff``
+    radius 10, DWMWCP_DONOTROUND                ``#ffffff``
+    radius 0, DWMWCP_ROUND                      the backdrop, correctly
+    ==========================================  ======================
+
+    So turning Windows' own rounding *off* fixes nothing: the notch is the
+    unpainted region, not the rounding.  The fix is to stop leaving a region
+    unpainted at all.  The QML side squares its background off on Windows
+    (see ``Main.qml``'s ``selfRoundedCorners``) and this hands the corner to
+    DWM, which masks an opaque window cleanly and antialiases it properly.
+
+    Best-effort by design.  ``DWMWA_WINDOW_CORNER_PREFERENCE`` is Windows 11
+    (build 22000) and later; on Windows 10 the call simply fails and the
+    window keeps the square corners the QML side gave it, which is what
+    every other window on a Windows 10 desktop looks like anyway.  A window
+    that fails to round is a cosmetic difference, never a reason to fail
+    startup, so nothing here is allowed to raise.
+
+    Guarded on ``sys.platform`` like every other function in this file, so
+    mypy prunes the ``ctypes.windll`` body under ``--platform linux``.
+    """
+    if sys.platform != "win32":
+        return
+
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        DWMWA_WINDOW_CORNER_PREFERENCE = 33
+        DWMWCP_ROUND = 2
+
+        dwmapi = ctypes.windll.dwmapi
+        preference = ctypes.c_int(DWMWCP_ROUND)
+        dwmapi.DwmSetWindowAttribute.argtypes = [
+            wintypes.HWND,
+            wintypes.DWORD,
+            ctypes.c_void_p,
+            wintypes.DWORD,
+        ]
+        dwmapi.DwmSetWindowAttribute.restype = ctypes.c_long
+        hresult = dwmapi.DwmSetWindowAttribute(
+            hwnd,
+            DWMWA_WINDOW_CORNER_PREFERENCE,
+            ctypes.byref(preference),
+            ctypes.sizeof(preference),
+        )
+        if hresult != 0:
+            # Expected on Windows 10, where the attribute does not exist.
+            _logger.debug(
+                "DWM corner rounding unavailable (hr=0x%08x); square corners",
+                hresult & 0xFFFFFFFF,
+            )
+    except Exception as e:  # pragma: no cover - defensive
+        _logger.debug("Could not set the DWM corner preference: %s", e)
 
 
 def set_app_user_model_id(app_id: str) -> None:

--- a/src/platform/windows_window.py
+++ b/src/platform/windows_window.py
@@ -171,6 +171,10 @@ def apply_extended_styles(root: QWindow, *, taskbar_button: bool = False) -> Non
 
         hwnd = int(root.winId())
 
+        # Before the style writes, not after: each of those returns early
+        # on failure, and the corner needs nothing they compute.
+        _prefer_dwm_rounded_corners(hwnd)
+
         # Read current extended style.  Both Get/Set return 0 on real
         # failure but 0 is also a valid style value, so disambiguate
         # via SetLastError(0) + GetLastError per MSDN guidance.
@@ -289,47 +293,42 @@ def apply_extended_styles(root: QWindow, *, taskbar_button: bool = False) -> Non
                 kernel32.GetLastError(),
             )
 
-        _prefer_dwm_rounded_corners(hwnd)
-
         _logger.info("Applied WS_EX_NOACTIVATE and placed the window in the topmost band")
     except Exception as e:
         _logger.warning("Failed to apply Windows extended styles: %s", e)
 
 
-def _prefer_dwm_rounded_corners(hwnd: object) -> None:
+def prefer_dwm_rounded_corners(window: QWindow) -> None:
+    """Hand a shown window's corners to DWM, and nothing else.
+
+    For a floating window that is allowed to take focus (the dashboard),
+    which therefore must not go through :func:`apply_extended_styles` and
+    its ``WS_EX_NOACTIVATE``.  Requires a valid ``winId()``.
+    """
+    if sys.platform != "win32":
+        return
+    try:
+        _prefer_dwm_rounded_corners(int(window.winId()))
+    except Exception as e:
+        _logger.debug("Could not reach the window's native handle: %s", e)
+
+
+def _prefer_dwm_rounded_corners(hwnd: int) -> None:
     """Ask Windows to round this window's corners, rather than doing it here.
 
-    Every window in this app is frameless *and* ``WS_EX_LAYERED``, and it
-    used to draw its own rounded corner as a ``radius`` on the QML
-    background rectangle.  That leaves the pixels outside the arc unpainted,
-    and on a layered window those do not composite the desktop the way a
-    transparent pixel should: they come back **white**.  What the user sees
-    is a small bright notch biting into one corner of the keyboard, whose
-    visibility depends on what happens to be behind it.
-
-    Measured against a magenta backdrop placed behind all four corners, with
-    the window otherwise configured exactly as it ships:
-
-    ==========================================  ======================
-    configuration                               corner pixel
-    ==========================================  ======================
-    radius 10, DWM default                      ``#ffffff``
-    radius 10, DWMWCP_DONOTROUND                ``#ffffff``
-    radius 0, DWMWCP_ROUND                      the backdrop, correctly
-    ==========================================  ======================
-
-    So turning Windows' own rounding *off* fixes nothing: the notch is the
-    unpainted region, not the rounding.  The fix is to stop leaving a region
-    unpainted at all.  The QML side squares its background off on Windows
-    (see ``Main.qml``'s ``selfRoundedCorners``) and this hands the corner to
-    DWM, which masks an opaque window cleanly and antialiases it properly.
+    The transparent windows here are ``WS_EX_LAYERED``, and a QML ``radius``
+    on a layered window leaves the corner pixels unpainted, which come back
+    white rather than transparent.  So the QML side squares its background
+    off on Windows (``Main.qml``'s ``selfRoundedCorners``) and this hands
+    the corner to DWM, which masks an opaque window and antialiases it.
+    The measurements and the full reasoning are under *Who rounds the
+    window corners* in ``CLAUDE.md``.
 
     Best-effort by design.  ``DWMWA_WINDOW_CORNER_PREFERENCE`` is Windows 11
-    (build 22000) and later; on Windows 10 the call simply fails and the
-    window keeps the square corners the QML side gave it, which is what
-    every other window on a Windows 10 desktop looks like anyway.  A window
-    that fails to round is a cosmetic difference, never a reason to fail
-    startup, so nothing here is allowed to raise.
+    (build 22000) and later; on Windows 10 the call fails and the window
+    keeps the square corners QML gave it, which is what every other window
+    on that desktop looks like anyway.  A window that fails to round is
+    cosmetic, never a reason to fail startup, so nothing here may raise.
 
     Guarded on ``sys.platform`` like every other function in this file, so
     mypy prunes the ``ctypes.windll`` body under ``--platform linux``.
@@ -365,7 +364,7 @@ def _prefer_dwm_rounded_corners(hwnd: object) -> None:
                 "DWM corner rounding unavailable (hr=0x%08x); square corners",
                 hresult & 0xFFFFFFFF,
             )
-    except Exception as e:  # pragma: no cover - defensive
+    except Exception as e:
         _logger.debug("Could not set the DWM corner preference: %s", e)
 
 

--- a/tests/test_window_corners.py
+++ b/tests/test_window_corners.py
@@ -1,0 +1,170 @@
+"""Who rounds the window's corners.
+
+Every window in this app is frameless and, on Windows, ``WS_EX_LAYERED``.
+Rounding a corner ourselves with a QML ``radius`` leaves the pixels outside
+the arc unpainted, and on a layered window those do not composite the
+desktop the way a transparent pixel should: they come back white. What the
+user sees is a bright notch biting into a corner of the keyboard.
+
+Measured on the real ``Main.qml`` against a magenta backdrop placed behind
+all four corners:
+
+===========================================  =========================
+configuration                                corner pixel
+===========================================  =========================
+radius 10, Windows 11 default rounding       ``#ffffff``
+radius 10, ``DWMWCP_DONOTROUND``             ``#ffffff``
+radius 0, ``DWMWCP_ROUND``                   the backdrop, correctly
+===========================================  =========================
+
+Turning Windows' own rounding off fixes nothing, which is the part worth
+remembering: the notch is the *unpainted region*, not the rounding. So on
+Windows the background is squared off and DWM masks the corner instead.
+
+**The compositing itself cannot be tested here.** The offscreen platform
+plugin has no compositor, and the offscreen render was correct the whole
+time this bug was visible on screen, so a test that rendered the corner and
+looked at it would have passed against the bug. What these tests pin is the
+half that is checkable: which side is asked to do the rounding, that every
+window agrees about it, and that the DWM call can never break startup.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+try:
+    from PySide6.QtCore import QCoreApplication, QSettings, QUrl  # noqa: E402
+    from PySide6.QtGui import QGuiApplication  # noqa: E402
+    from PySide6.QtQml import QQmlApplicationEngine  # noqa: E402
+    from PySide6.QtQuick import QQuickItem  # noqa: E402
+except ImportError as exc:  # pragma: no cover - environment-dependent
+    pytest.skip(
+        f"Qt GUI libraries unavailable ({exc}); install libegl1/libgl1 to run "
+        "the headless QML tests",
+        allow_module_level=True,
+    )
+
+from src.keyboard_bridge import KeyboardBridge  # noqa: E402
+from tests.qml_context import install_context_properties  # noqa: E402
+from tests.qt_settings_scope import TEST_APP, TEST_ORG  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+QML_MAIN = REPO_ROOT / "qml" / "Main.qml"
+
+ON_WINDOWS = sys.platform == "win32"
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QGuiApplication.instance()
+    if app is None:
+        QCoreApplication.setOrganizationName(TEST_ORG)
+        QCoreApplication.setApplicationName(TEST_APP)
+        app = QGuiApplication([])
+    assert QCoreApplication.organizationName() == TEST_ORG, (
+        "another test already created a QGuiApplication under a different "
+        "organisation - these tests would write to the real user's settings"
+    )
+    return app
+
+
+@pytest.fixture
+def qml_root(qapp):
+    QSettings(TEST_ORG, TEST_APP).clear()
+    settings = QSettings(TEST_ORG, TEST_APP)
+    settings.setValue("ui/savedAutoCheckUpdates", False)
+    settings.sync()
+
+    with patch("src.keyboard_bridge.create_key_synthesizer") as factory:
+        synth = MagicMock()
+        synth.is_available.return_value = True
+        synth.backend_name.return_value = "MockSynth"
+        factory.return_value = synth
+        bridge = KeyboardBridge()
+
+    warnings: list[str] = []
+    engine = QQmlApplicationEngine()
+    engine.warnings.connect(lambda errs: warnings.extend(e.toString() for e in errs))
+    install_context_properties(engine, bridge)
+    engine.load(QUrl.fromLocalFile(str(QML_MAIN)))
+    assert engine.rootObjects(), "qml/Main.qml failed to load:\n  " + "\n  ".join(warnings)
+    root = engine.rootObjects()[0]
+    QCoreApplication.processEvents()
+    try:
+        yield root
+    finally:
+        del engine
+
+
+class TestWhoRoundsTheCorners:
+    def test_windows_hands_the_corner_to_the_compositor(self, qml_root) -> None:
+        root = qml_root
+        self_rounded = root.property("selfRoundedCorners")
+        assert self_rounded is (not ON_WINDOWS), (
+            "on Windows the background must be square so nothing is left "
+            "unpainted; everywhere else we round it ourselves"
+        )
+
+    def test_the_radius_follows_that_decision(self, qml_root) -> None:
+        root = qml_root
+        radius = root.property("windowRadius")
+        assert radius == (0 if ON_WINDOWS else 10)
+
+    def test_the_background_actually_uses_it(self, qml_root) -> None:
+        # The property is only worth anything if the rectangle is bound to
+        # it; a stale literal on the Rectangle would satisfy the two tests
+        # above and still paint the notch.
+        root = qml_root
+        background = root.findChild(QQuickItem, "windowBackground")
+        assert background is not None, "windowBackground not found"
+        assert background.property("radius") == root.property("windowRadius")
+
+    def test_every_window_agrees(self, qml_root) -> None:
+        # The snippets and symbols windows are frameless and transparent in
+        # exactly the same way, so a fix that reached only the keyboard
+        # would leave the notch on the two windows that float over the app
+        # the user is typing into.
+        root = qml_root
+        expected = root.property("selfRoundedCorners")
+        for name in ("snippetsWindow", "symbolsWindow"):
+            # These are Windows rather than Items, so a QQuickItem-typed
+            # findChild returns None and every assertion after it would
+            # silently never run.
+            window = next(
+                (c for c in root.findChildren(object) if c.objectName() == name),
+                None,
+            )
+            assert window is not None, f"{name} not found"
+            assert window.property("selfRoundedCorners") == expected, (
+                f"{name} disagrees with the keyboard about who rounds corners"
+            )
+
+
+@pytest.mark.skipif(not ON_WINDOWS, reason="DWM is Windows-only")
+class TestTheDwmCallIsSafe:
+    def test_it_never_raises_when_dwm_refuses(self) -> None:
+        # Windows 10 has no DWMWA_WINDOW_CORNER_PREFERENCE, so the call
+        # fails there by design and the window keeps square corners. A
+        # cosmetic difference is never a reason to fail startup.
+        from src.platform import windows_window
+
+        with patch("ctypes.windll") as windll:
+            windll.dwmapi.DwmSetWindowAttribute.return_value = -2147024809
+            windows_window._prefer_dwm_rounded_corners(0)
+
+    def test_it_swallows_a_missing_dwmapi(self) -> None:
+        from src.platform import windows_window
+
+        with patch("ctypes.windll") as windll:
+            windll.dwmapi.DwmSetWindowAttribute.side_effect = OSError("no dwmapi")
+            windows_window._prefer_dwm_rounded_corners(0)

--- a/tests/test_window_corners.py
+++ b/tests/test_window_corners.py
@@ -1,38 +1,26 @@
 """Who rounds the window's corners.
 
-Every window in this app is frameless and, on Windows, ``WS_EX_LAYERED``.
-Rounding a corner ourselves with a QML ``radius`` leaves the pixels outside
-the arc unpainted, and on a layered window those do not composite the
-desktop the way a transparent pixel should: they come back white. What the
-user sees is a bright notch biting into a corner of the keyboard.
-
-Measured on the real ``Main.qml`` against a magenta backdrop placed behind
-all four corners:
-
-===========================================  =========================
-configuration                                corner pixel
-===========================================  =========================
-radius 10, Windows 11 default rounding       ``#ffffff``
-radius 10, ``DWMWCP_DONOTROUND``             ``#ffffff``
-radius 0, ``DWMWCP_ROUND``                   the backdrop, correctly
-===========================================  =========================
-
-Turning Windows' own rounding off fixes nothing, which is the part worth
-remembering: the notch is the *unpainted region*, not the rounding. So on
-Windows the background is squared off and DWM masks the corner instead.
+The transparent windows here are ``WS_EX_LAYERED`` on Windows, and a QML
+``radius`` on a layered window leaves corner pixels that come back white
+rather than transparent: a bright notch biting into a corner of the
+keyboard. So on Windows the background is squared off and DWM masks the
+corner instead. The measurements and the reasoning are under *Who rounds
+the window corners* in ``CLAUDE.md``.
 
 **The compositing itself cannot be tested here.** The offscreen platform
 plugin has no compositor, and the offscreen render was correct the whole
 time this bug was visible on screen, so a test that rendered the corner and
 looked at it would have passed against the bug. What these tests pin is the
 half that is checkable: which side is asked to do the rounding, that every
-window agrees about it, and that the DWM call can never break startup.
+transparent window agrees about it, what the DWM call asks for, and that it
+can never break startup.
 """
 
 from __future__ import annotations
 
 import os
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -43,7 +31,7 @@ pytest.importorskip("PySide6")
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 try:
-    from PySide6.QtCore import QCoreApplication, QSettings, QUrl  # noqa: E402
+    from PySide6.QtCore import QCoreApplication, QObject, QSettings, QUrl  # noqa: E402
     from PySide6.QtGui import QGuiApplication  # noqa: E402
     from PySide6.QtQml import QQmlApplicationEngine  # noqa: E402
     from PySide6.QtQuick import QQuickItem  # noqa: E402
@@ -55,6 +43,7 @@ except ImportError as exc:  # pragma: no cover - environment-dependent
     )
 
 from src.keyboard_bridge import KeyboardBridge  # noqa: E402
+from src.platform import windows_window  # noqa: E402
 from tests.qml_context import install_context_properties  # noqa: E402
 from tests.qt_settings_scope import TEST_APP, TEST_ORG  # noqa: E402
 
@@ -62,6 +51,20 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 QML_MAIN = REPO_ROOT / "qml" / "Main.qml"
 
 ON_WINDOWS = sys.platform == "win32"
+
+IGNORED_WARNING_FRAGMENTS = ("does not support customization",)
+
+# The windows whose background is transparent, and therefore layered on
+# Windows.  Each names the object carrying `selfRoundedCorners`: the two
+# pickers hold it on the Window, the dashboard on the panel filling it.
+TRANSPARENT_WINDOWS = ("snippetsWindow", "symbolsWindow", "vizContent")
+
+DWMWA_WINDOW_CORNER_PREFERENCE = 33
+DWMWCP_ROUND = 2
+
+
+def _real_warnings(warnings: list[str]) -> list[str]:
+    return [w for w in warnings if not any(f in w for f in IGNORED_WARNING_FRAGMENTS)]
 
 
 @pytest.fixture(scope="module")
@@ -78,8 +81,13 @@ def qapp():
     return app
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def qml_root(qapp):
+    """Main.qml, loaded once for the module.
+
+    Every test here only reads properties, so one load serves them all; the
+    sibling QML modules reload per test because their tests mutate state.
+    """
     QSettings(TEST_ORG, TEST_APP).clear()
     settings = QSettings(TEST_ORG, TEST_APP)
     settings.setValue("ui/savedAutoCheckUpdates", False)
@@ -101,70 +109,122 @@ def qml_root(qapp):
     root = engine.rootObjects()[0]
     QCoreApplication.processEvents()
     try:
-        yield root
+        yield root, warnings
     finally:
         del engine
 
 
 class TestWhoRoundsTheCorners:
     def test_windows_hands_the_corner_to_the_compositor(self, qml_root) -> None:
-        root = qml_root
-        self_rounded = root.property("selfRoundedCorners")
-        assert self_rounded is (not ON_WINDOWS), (
-            "on Windows the background must be square so nothing is left "
-            "unpainted; everywhere else we round it ourselves"
-        )
-
-    def test_the_radius_follows_that_decision(self, qml_root) -> None:
-        root = qml_root
-        radius = root.property("windowRadius")
-        assert radius == (0 if ON_WINDOWS else 10)
+        # On Windows the background must be square so nothing is left
+        # unpainted; everywhere else we round it ourselves.  The radius is
+        # the same decision expressed in pixels.
+        root, warnings = qml_root
+        assert root.property("selfRoundedCorners") is (not ON_WINDOWS)
+        assert root.property("windowRadius") == (0 if ON_WINDOWS else 10)
+        assert _real_warnings(warnings) == []
 
     def test_the_background_actually_uses_it(self, qml_root) -> None:
         # The property is only worth anything if the rectangle is bound to
-        # it; a stale literal on the Rectangle would satisfy the two tests
-        # above and still paint the notch.
-        root = qml_root
+        # it; a stale literal on the Rectangle would satisfy the test above
+        # and still paint the notch.
+        root, _ = qml_root
         background = root.findChild(QQuickItem, "windowBackground")
         assert background is not None, "windowBackground not found"
         assert background.property("radius") == root.property("windowRadius")
 
-    def test_every_window_agrees(self, qml_root) -> None:
-        # The snippets and symbols windows are frameless and transparent in
-        # exactly the same way, so a fix that reached only the keyboard
-        # would leave the notch on the two windows that float over the app
-        # the user is typing into.
-        root = qml_root
+    def test_every_transparent_window_agrees(self, qml_root) -> None:
+        # The pickers and the dashboard are transparent in exactly the same
+        # way, so a fix that reached only the keyboard would leave the notch
+        # on the windows that float over the app the user is typing into.
+        # The dashboard was missed once, which is why the list is named.
+        root, _ = qml_root
         expected = root.property("selfRoundedCorners")
-        for name in ("snippetsWindow", "symbolsWindow"):
-            # These are Windows rather than Items, so a QQuickItem-typed
-            # findChild returns None and every assertion after it would
-            # silently never run.
-            window = next(
-                (c for c in root.findChildren(object) if c.objectName() == name),
-                None,
-            )
-            assert window is not None, f"{name} not found"
-            assert window.property("selfRoundedCorners") == expected, (
+        for name in TRANSPARENT_WINDOWS:
+            # Two of these are Windows rather than Items, so the lookup is
+            # typed on QObject; a QQuickItem-typed findChild returns None
+            # for them and every assertion after it would never run.
+            target = root.findChild(QObject, name)
+            assert target is not None, f"{name} not found"
+            assert target.property("selfRoundedCorners") == expected, (
                 f"{name} disagrees with the keyboard about who rounds corners"
             )
 
+    def test_the_screenshot_script_can_take_the_rounding_back(self, qml_root) -> None:
+        # capture_screenshots.py renders through the offscreen plugin, where
+        # Qt.platform.os still says "windows" but nothing composites the
+        # corner, so it sets this back.  A readonly property would make
+        # that assignment a silent no-op.
+        root, _ = qml_root
+        before = root.property("selfRoundedCorners")
+        try:
+            root.setProperty("selfRoundedCorners", True)
+            assert root.property("windowRadius") == 10
+            assert root.findChild(QObject, "vizContent").property("selfRoundedCorners") is True
+        finally:
+            root.setProperty("selfRoundedCorners", before)
 
-@pytest.mark.skipif(not ON_WINDOWS, reason="DWM is Windows-only")
-class TestTheDwmCallIsSafe:
-    def test_it_never_raises_when_dwm_refuses(self) -> None:
+
+class TestTheDwmCall:
+    """The Win32 half, run on every platform through a fake ``windll``.
+
+    ``sys.platform`` is patched to ``win32`` for the duration, the same
+    arrangement ``tests/test_windows_window.py`` uses, so the body mypy
+    prunes under ``--platform linux`` is still exercised on the Linux shards.
+    """
+
+    @pytest.fixture
+    def windll(self, monkeypatch: pytest.MonkeyPatch) -> Iterator[MagicMock]:
+        monkeypatch.setattr(sys, "platform", "win32")
+        fake = MagicMock()
+        fake.dwmapi.DwmSetWindowAttribute.return_value = 0
+        with patch("ctypes.windll", fake):
+            yield fake
+
+    def test_it_asks_for_round_corners(self, windll: MagicMock) -> None:
+        # The constants are what make the call mean anything: a transposed
+        # attribute id or DWMWCP_DONOTROUND would be swallowed silently.
+        windows_window._prefer_dwm_rounded_corners(0x1234)
+        (hwnd, attribute, value, size), _ = windll.dwmapi.DwmSetWindowAttribute.call_args
+        assert hwnd == 0x1234
+        assert attribute == DWMWA_WINDOW_CORNER_PREFERENCE
+        assert value._obj.value == DWMWCP_ROUND
+        assert size == 4
+
+    def test_apply_extended_styles_reaches_it_before_any_early_return(
+        self, windll: MagicMock
+    ) -> None:
+        # A failed style read returns early and is logged; the corner needs
+        # nothing that read computes, so it must not be lost with it.
+        windll.kernel32.GetLastError.return_value = 5
+        windll.user32.GetWindowLongW.return_value = 0
+        root = MagicMock()
+        root.winId.return_value = 0x1234
+        windows_window.apply_extended_styles(root)
+        windll.dwmapi.DwmSetWindowAttribute.assert_called_once()
+
+    def test_the_dashboard_gets_only_the_corner(self, windll: MagicMock) -> None:
+        # The dashboard is allowed to take focus, so it must not go through
+        # apply_extended_styles and pick up WS_EX_NOACTIVATE with the corner.
+        window = MagicMock()
+        window.winId.return_value = 0x1234
+        windows_window.prefer_dwm_rounded_corners(window)
+        windll.dwmapi.DwmSetWindowAttribute.assert_called_once()
+        windll.user32.SetWindowLongW.assert_not_called()
+
+    def test_it_never_raises_when_dwm_refuses(self, windll: MagicMock) -> None:
         # Windows 10 has no DWMWA_WINDOW_CORNER_PREFERENCE, so the call
         # fails there by design and the window keeps square corners. A
         # cosmetic difference is never a reason to fail startup.
-        from src.platform import windows_window
+        windll.dwmapi.DwmSetWindowAttribute.return_value = -2147024809
+        windows_window._prefer_dwm_rounded_corners(0)
 
-        with patch("ctypes.windll") as windll:
-            windll.dwmapi.DwmSetWindowAttribute.return_value = -2147024809
-            windows_window._prefer_dwm_rounded_corners(0)
+    def test_it_swallows_a_missing_dwmapi(self, windll: MagicMock) -> None:
+        windll.dwmapi.DwmSetWindowAttribute.side_effect = OSError("no dwmapi")
+        windows_window._prefer_dwm_rounded_corners(0)
 
-    def test_it_swallows_a_missing_dwmapi(self) -> None:
-        from src.platform import windows_window
-
-        with patch("ctypes.windll") as windll:
-            windll.dwmapi.DwmSetWindowAttribute.side_effect = OSError("no dwmapi")
-            windows_window._prefer_dwm_rounded_corners(0)
+    def test_a_window_with_no_native_handle_is_left_alone(self, windll: MagicMock) -> None:
+        window = MagicMock()
+        window.winId.side_effect = RuntimeError("not created yet")
+        windows_window.prefer_dwm_rounded_corners(window)
+        windll.dwmapi.DwmSetWindowAttribute.assert_not_called()

--- a/tests/test_window_corners.py
+++ b/tests/test_window_corners.py
@@ -178,7 +178,9 @@ class TestTheDwmCall:
         monkeypatch.setattr(sys, "platform", "win32")
         fake = MagicMock()
         fake.dwmapi.DwmSetWindowAttribute.return_value = 0
-        with patch("ctypes.windll", fake):
+        # `create`: the attribute only exists on Windows, and these run on
+        # the Linux shards too.
+        with patch("ctypes.windll", fake, create=True):
             yield fake
 
     def test_it_asks_for_round_corners(self, windll: MagicMock) -> None:

--- a/tests/test_windows_window.py
+++ b/tests/test_windows_window.py
@@ -55,11 +55,19 @@ class TestAlwaysOnTopIsAppliedAsAZOrderChange:
         user32.SetWindowPos.return_value = 1
         kernel32 = MagicMock()
         kernel32.GetLastError.return_value = 0
+        # apply_extended_styles also asks DWM to round the corners; without
+        # this the call raised AttributeError into its own except clause and
+        # every test here exercised the failure path without saying so.
+        dwmapi = MagicMock()
+        dwmapi.DwmSetWindowAttribute.return_value = 0
 
         import ctypes
 
         monkeypatch.setattr(
-            ctypes, "windll", types.SimpleNamespace(user32=user32, kernel32=kernel32), raising=False
+            ctypes,
+            "windll",
+            types.SimpleNamespace(user32=user32, kernel32=kernel32, dwmapi=dwmapi),
+            raising=False,
         )
         # The real function returns early off Windows so mypy can prune the
         # ctypes body under --platform linux.  The suite runs on Linux too,
@@ -166,11 +174,19 @@ class TestTheKeyboardKeepsItsTaskbarButton:
         user32.SetWindowPos.side_effect = _set_window_pos
         kernel32 = MagicMock()
         kernel32.GetLastError.return_value = 0
+        # apply_extended_styles also asks DWM to round the corners; without
+        # this the call raised AttributeError into its own except clause and
+        # every test here exercised the failure path without saying so.
+        dwmapi = MagicMock()
+        dwmapi.DwmSetWindowAttribute.return_value = 0
 
         import ctypes
 
         monkeypatch.setattr(
-            ctypes, "windll", types.SimpleNamespace(user32=user32, kernel32=kernel32), raising=False
+            ctypes,
+            "windll",
+            types.SimpleNamespace(user32=user32, kernel32=kernel32, dwmapi=dwmapi),
+            raising=False,
         )
         # The real function returns early off Windows so mypy can prune the
         # ctypes body under --platform linux.  The suite runs on Linux too,


### PR DESCRIPTION
## Summary

A small bright notch bites into a corner of the keyboard on Windows. It
comes and goes depending on what is behind the window, which is why it reads
as intermittent and unrelated to anything.

Every window in this app is frameless and `WS_EX_LAYERED`, and each rounded
its own corners with a `radius` on the QML background rectangle. That leaves
the pixels outside the arc unpainted, and **on a layered window those do not
composite the desktop the way a transparent pixel should: they come back
white**.

## Evidence

Measured on the real `Main.qml`, with a magenta backdrop placed behind all
four corners so "what shows through" is a colour nothing else on the desktop
would be:

| configuration | corner pixel |
|---|---|
| radius 10, Windows 11 default rounding (**ships today**) | `#ffffff` |
| radius 10, `DWMWCP_DONOTROUND` | `#ffffff` |
| radius 0, `DWMWCP_ROUND` | the backdrop, correctly |

The middle row is the useful one: **turning Windows' own rounding off fixes
nothing.** The notch is the unpainted region, not the rounding, so the fix
has to be to leave nothing unpainted.

After the change, all four corners of the real window report **zero** white
pixels and show the backdrop, DWM-rounded and antialiased.

## What changed

- `Main.qml` gains `selfRoundedCorners` (false on Windows) and
  `windowRadius`, applied to the background, the title bar and the shadow.
  The title bar has to follow the background: rounding it over a square
  background swaps the notch for a lighter wedge, since what shows through
  is then the background rather than the desktop.
- `windows_window.py::_prefer_dwm_rounded_corners` sets
  `DWMWA_WINDOW_CORNER_PREFERENCE` to `DWMWCP_ROUND`, so the compositor
  masks an opaque window.
- `SnippetsWindow` and `SymbolsWindow` are transparent with a radius-8
  background in exactly the same way, so they take the same decision as a
  required property from `Main.qml` rather than each reading
  `Qt.platform.os`. A fix reaching only the keyboard would have left the
  notch on the two windows that float over whatever the user is typing into.

## Notes for review

- **The DWM call is best-effort and should stay that way.**
  `DWMWA_WINDOW_CORNER_PREFERENCE` is Windows 11 and later; on Windows 10 it
  fails and the window keeps the square corners QML gave it, which is what
  every other window on that desktop looks like. A window that fails to
  round is cosmetic, never a reason to fail startup. It carries the same
  `sys.platform` guard every other function in that file has, so mypy prunes
  the `ctypes.windll` body under `--platform linux`.
- Nothing changes off Windows: `selfRoundedCorners` is true there and the
  radius stays 10.

## Test plan

- `python check.py` passes: ruff, ruff-format, mypy under both platforms,
  full pytest.
- New `tests/test_window_corners.py`. **It deliberately does not render the
  corner and look at it**: the offscreen platform plugin has no compositor,
  and the offscreen render was correct the whole time this was visible on
  screen, so such a test would have passed against the bug. It pins what is
  checkable instead: which side is asked to round, that the rectangle is
  actually bound to the property rather than carrying a stale literal, that
  all three windows agree, and that the DWM call cannot raise.
- Verified by hand on the real window, over a known backdrop, before and
  after.


## Review fixes

A multi-angle review of the first commit turned up the following, all fixed in the follow-up commits:

- **The Dashboard window was missed.** It is transparent with a radius-10 panel in exactly the way the two pickers are, so the notch was still there on *Your Language Model*. It now binds `selfRoundedCorners` like them and is named in `_wire_floating_windows`, where it gets only the DWM corner call: it is allowed to take focus (it has no keys on it), so it must not go through `apply_extended_styles` and pick up `WS_EX_NOACTIVATE` with the corner.
- **The DWM call sat after two early returns** in `apply_extended_styles`, so a failed style read or write would have cost the corner too. It runs before them now, and a test drives that path.
- **Screenshots would have regenerated square.** `Qt.platform.os` still reads `"windows"` under the offscreen plugin, where there is no compositor to round anything, so `capture_screenshots.py` sets `selfRoundedCorners` back to true after loading `Main.qml`. The property is no longer `readonly` for that one caller.
- **The CLAUDE.md claim was too broad.** "Every window is layered" is false for Settings and Help, which are opaque and whose rounded panels show the window's own dark colour in the corners rather than white; the rule is narrowed to the four transparent windows and says what a new one has to do.
- **The measurement table was restated in five places.** It now lives once, in CLAUDE.md, with the code comments pointing at it.
- **Tests.** Loaded once per module, assert on QML warnings like their siblings, use `findChild(QObject, name)`, check what the DWM call asks for (attribute 33, value 2) and that the dashboard path never touches the style word, and run on every platform through a fake `windll` (which needed `create=True` on the Linux shards). The existing window-style harness gains a `dwmapi` so it stops exercising the failure path unannounced.

**Not verified on a real desktop:** the background keeps its 1 px theme border while its radius is 0, so along the corner arc DWM's mask clips that border and draws its own. If that reads wrong on a light theme, the answer is `DWMWA_BORDER_COLOR`, not a radius on the QML side. Noted in CLAUDE.md.
