### PR TITLE
fix(installer): show the study link, and say the ten numbers are counts

### DIFF
--- a/build/windows/build.py
+++ b/build/windows/build.py
@@ -698,6 +698,9 @@ Page custom StudyInvitePage StudyInviteLeave
 ;  Shortcut Options Page
 ; ============================================================
 Function ShortcutOptionsPage
+  ; Without this the header still reads "Choose Install Location", carried
+  ; over from MUI_PAGE_DIRECTORY: a custom page sets no header of its own.
+  !insertmacro MUI_HEADER_TEXT "Shortcuts" "Choose which shortcuts to create."
   nsDialogs::Create 1018
   Pop $0
   ${{If}} $0 == error
@@ -731,37 +734,49 @@ FunctionEnd
 ; wizard pages, so $StudyInvite stays "" on every auto-update and the
 ; registry seed below is simply never written on that path.
 Function StudyInvitePage
+  ; See the note in ShortcutOptionsPage: without this the header reads
+  ; "Choose Install Location" over a page about research participation.
+  !insertmacro MUI_HEADER_TEXT "Help improve Alpha-OSK" "Optional. Share ten anonymous totals about your typing."
   nsDialogs::Create 1018
   Pop $0
   ${{If}} $0 == error
     Abort
   ${{EndIf}}
 
-  ${{NSD_CreateLabel}} 0 0u 100% 12u "Help improve Alpha-OSK (optional)"
+  ; ---------------------------------------------------------------
+  ; LAYOUT BUDGET: the page area is exactly 140u tall.  A control
+  ; placed past that is clipped by its parent dialog and simply never
+  ; draws -- it still reports itself visible, so this fails silently.
+  ; The "Read more" link shipped at 144u and was invisible for exactly
+  ; that reason.  Nothing below may end past 140u; the guard is
+  ; tests/test_windows_installer.py::TestTheStudyPageFitsItsDialog.
+  ; ---------------------------------------------------------------
+  ; No in-page title: the header set above already reads "Help improve
+  ; Alpha-OSK", and repeating it here cost a line of a page that has none
+  ; to spare.
+  ;
+  ; Say plainly that these are COUNTS before naming any of them.  The
+  ; first wording led with "keystrokes, words, ..." as a bare list, which
+  ; reads as though the typed text itself is sent.
+  ${{NSD_CreateLabel}} 0 0u 100% 26u "Once a week, Alpha-OSK can send ten numbers. Every one is a total: a count of how often something happened. None of them contain anything you typed."
   Pop $1
 
-  ${{NSD_CreateLabel}} 0 16u 100% 28u "Alpha-OSK's predictions are only measured in simulation today. Real usage from people who actually type with it is what would show whether they help in practice."
+  ${{NSD_CreateLabel}} 0 28u 100% 38u "The ten: how many keys you pressed, how many words you finished, how many predictions were offered, how many you accepted, how many keys those saved you, how many minutes you typed, and how many times you opened Alpha-OSK. With a random ID for this install, the app version, and which operating system."
   Pop $2
 
-  ${{NSD_CreateLabel}} 0 48u 100% 42u "Ten numbers, once a week: a random ID, app version, operating system, keystrokes, words, predictions accepted, keystrokes saved, minutes of use, sessions, predictions offered."
+  ${{NSD_CreateLabel}} 0 68u 100% 26u "Never the words you type, your files, your screen, or your IP address. You can change this any time in Settings, or delete everything you have shared."
   Pop $3
 
-  ${{NSD_CreateLabel}} 0 94u 100% 12u "Never the words you type. Never your files, your screen, or your IP address."
+  ${{NSD_CreateLink}} 0 97u 100% 12u "Read more about the study"
   Pop $4
-
-  ${{NSD_CreateLabel}} 0 108u 100% 12u "You can change this at any time in Settings, or delete everything you have shared."
-  Pop $5
+  ${{NSD_OnClick}} $4 StudyInviteLinkClick
 
   ; DEFAULT MUST STAY UNCHECKED. Do not add a ${{NSD_SetState}} ...
   ; ${{BST_CHECKED}} call here: a pre-ticked consent box is not consent,
   ; it is the one thing that would make this data unusable as research
   ; and non-compliant as a privacy control.
-  ${{NSD_CreateCheckbox}} 0 128u 100% 12u "Yes, share anonymous usage statistics"
+  ${{NSD_CreateCheckbox}} 0 112u 100% 12u "Yes, share anonymous usage statistics"
   Pop $StudyInviteCheckboxHwnd
-
-  ${{NSD_CreateLink}} 0 144u 100% 12u "Read more about the study"
-  Pop $6
-  ${{NSD_OnClick}} $6 StudyInviteLinkClick
 
   nsDialogs::Show
 FunctionEnd

--- a/tests/test_windows_installer.py
+++ b/tests/test_windows_installer.py
@@ -118,9 +118,16 @@ class TestTheInviteePageIsPlacedRight:
         assert shortcut < invite < instfiles
 
     def test_the_page_content_names_what_is_sent(self, nsi: str) -> None:
+        """Pins the page's four jobs, not its exact wording.
+
+        This used to assert the literal opening sentence, which made an
+        ordinary copy edit look like a regression while saying nothing about
+        whether the page still explains itself. TestTheStudyPageSaysTheseAreCounts
+        below covers the one claim the wording actually has to make.
+        """
         body = _function_body(nsi, "StudyInvitePage")
         assert "Help improve Alpha-OSK" in body
-        assert "Ten numbers, once a week" in body
+        assert "ten numbers" in body.lower()
         assert "Never the words you type" in body
         assert "Read more about the study" in body
 
@@ -282,3 +289,121 @@ class TestTheInteractiveUninstallStillOffersToRemoveIt:
         label = next(i for i, ln in enumerate(lines) if ln == f"{skip_label}:")
         assert silent < deletion < label, "the settings deletion is not behind IfSilent"
         assert silent < appdata < label, "the AppData removal is not behind IfSilent"
+
+
+# The page area inside nsDialogs::Create 1018 is exactly this tall. Measured
+# from the live dialog: the checkbox that shipped at 128u..140u had its bottom
+# edge exactly on the parent's, and the link at 144u..156u was clipped 39px
+# past it. A control placed below this is silently invisible -- Windows clips a
+# child to its parent, but the control still reports itself visible, so nothing
+# fails and nobody notices until they look at a screenshot.
+PAGE_AREA_UNITS = 140
+
+_NSD_CONTROL = re.compile(r"\$\{NSD_Create(\w+)\}\s+\S+\s+(\d+)u\s+\S+\s+(\d+)u\s+\"([^\"]*)\"")
+
+
+def _controls(nsi_text: str, function_name: str):
+    """(kind, top, height, text) for every control a page function creates."""
+    body = _function_body(nsi_text, function_name)
+    return [
+        (m.group(1), int(m.group(2)), int(m.group(3)), m.group(4))
+        for m in _NSD_CONTROL.finditer(body)
+    ]
+
+
+class TestTheStudyPageFitsItsDialog:
+    """Every control has to end inside the page area or it never draws.
+
+    This is the regression guard for a real defect: "Read more about the
+    study" shipped at 144u, 39px below the page area, and was invisible in
+    the installer while every text-matching test passed.
+    """
+
+    def test_the_page_creates_the_controls_it_is_supposed_to(self, nsi: str) -> None:
+        kinds = [c[0] for c in _controls(nsi, "StudyInvitePage")]
+        assert "Checkbox" in kinds, "the consent checkbox is gone"
+        assert "Link" in kinds, "the read-more link is gone"
+        assert kinds.count("Label") >= 3, f"expected the explanatory labels, got {kinds}"
+
+    def test_no_control_ends_past_the_page_area(self, nsi: str) -> None:
+        overflowing = [
+            (kind, top, height, text[:40])
+            for kind, top, height, text in _controls(nsi, "StudyInvitePage")
+            if top + height > PAGE_AREA_UNITS
+        ]
+        assert not overflowing, (
+            f"these end past {PAGE_AREA_UNITS}u and will be clipped invisible: {overflowing}"
+        )
+
+    def test_the_read_more_link_is_well_inside_the_page(self, nsi: str) -> None:
+        """Named separately from the sweep above: this is the control that
+        actually shipped broken, so it gets an assertion that says so."""
+        link = [c for c in _controls(nsi, "StudyInvitePage") if c[0] == "Link"]
+        assert len(link) == 1, f"expected exactly one link, got {link}"
+        _, top, height, _ = link[0]
+        assert top + height <= PAGE_AREA_UNITS, (
+            f"the read-more link ends at {top + height}u, past the {PAGE_AREA_UNITS}u "
+            "page area, so it is clipped and never renders"
+        )
+
+    def test_controls_do_not_overlap_each_other(self, nsi: str) -> None:
+        """A control laid out on top of another hides it just as thoroughly."""
+        ordered = sorted(_controls(nsi, "StudyInvitePage"), key=lambda c: c[1])
+        for (k1, t1, h1, x1), (k2, t2, _, x2) in zip(ordered, ordered[1:]):
+            assert t1 + h1 <= t2, (
+                f"{k1} {x1[:30]!r} ({t1}u..{t1 + h1}u) overlaps {k2} {x2[:30]!r} starting at {t2}u"
+            )
+
+
+class TestTheCustomPagesSetTheirOwnHeader:
+    """A custom page inherits the previous MUI page's header unless it sets one.
+
+    Both of these read "Choose Install Location" over unrelated content until
+    the MUI_HEADER_TEXT calls were added.
+    """
+
+    @pytest.mark.parametrize("function_name", ["ShortcutOptionsPage", "StudyInvitePage"])
+    def test_the_page_sets_a_header(self, nsi: str, function_name: str) -> None:
+        body = _function_body(nsi, function_name)
+        assert "MUI_HEADER_TEXT" in body, (
+            f"{function_name} sets no header, so it inherits the previous page's"
+        )
+
+    @pytest.mark.parametrize("function_name", ["ShortcutOptionsPage", "StudyInvitePage"])
+    def test_the_header_is_set_before_the_dialog_is_created(
+        self, nsi: str, function_name: str
+    ) -> None:
+        """MUI_HEADER_TEXT after nsDialogs::Show is never reached: Show blocks
+        until the user leaves the page."""
+        body = _function_body(nsi, function_name)
+        assert body.index("MUI_HEADER_TEXT") < body.index("nsDialogs::Show")
+
+    def test_neither_header_still_says_choose_install_location(self, nsi: str) -> None:
+        """The inverse: a header that merely exists but repeats the directory
+        page's text would satisfy the assertions above and fix nothing."""
+        for function_name in ("ShortcutOptionsPage", "StudyInvitePage"):
+            body = _function_body(nsi, function_name)
+            header = re.search(r'MUI_HEADER_TEXT\s+"([^"]*)"', body)
+            assert header, f"{function_name} has no header text"
+            assert "install location" not in header.group(1).lower()
+
+
+class TestTheStudyPageSaysTheseAreCounts:
+    """The numbers are totals, not content, and the page has to say so.
+
+    The first wording opened with a bare list ("keystrokes, words, ...") that
+    read as though the typed text itself is sent. That is the single most
+    important thing this page communicates, so it is pinned.
+    """
+
+    def test_it_says_the_numbers_are_totals_or_counts(self, nsi: str) -> None:
+        text = " ".join(c[3].lower() for c in _controls(nsi, "StudyInvitePage"))
+        assert "total" in text or "count" in text, (
+            "the page never says the ten numbers are counts, so a bare list of "
+            "'keystrokes, words' reads as though the text is sent"
+        )
+
+    def test_it_says_nothing_typed_is_included(self, nsi: str) -> None:
+        text = " ".join(c[3].lower() for c in _controls(nsi, "StudyInvitePage"))
+        assert "never the words you type" in text
+        assert "anything you typed" in text or "nothing you type" in text


### PR DESCRIPTION
Three problems on the installer's research-participation page, all found by compiling the real wizard and capturing it rather than by reading the source. **Telemetry change flagged per CLAUDE.md**: this is the consent surface. No change to the payload, the endpoint, or the consent model, and the checkbox still ships unchecked.

## The link was invisible

`NSD_CreateLink` sat at `y=144u`. The page area inside `nsDialogs::Create 1018` is exactly **140u**, so the link was clipped 39 px below its parent and never drew. Measured against the live dialog: parent bottom 1242, control bottom 1281.

Nothing failed, and that is the part worth noting. Windows clips a child to its parent, but the control still reports itself visible, and every test in this file matched source *text*. A user had no route from the installer to the study page.

The consent checkbox was also sitting exactly on the boundary (bottom 1242 against a parent bottom of 1242) with zero margin: one more line of copy and it would have followed the link out of view.

## The copy read as though it sends what you type

It opened with a paragraph about predictions being measured in simulation, which says nothing a participant can act on, then listed the payload as bare nouns: "keystrokes, words, predictions accepted, keystrokes saved". Reported as: *"It seems like it's sending all keystrokes."*

It now states the shape before the contents, and names each item as a quantity:

> Once a week, Alpha-OSK can send ten numbers. Every one is a total: a count of how often something happened. None of them contain anything you typed.
>
> The ten: how many keys you pressed, how many words you finished, how many predictions were offered, how many you accepted, how many keys those saved you, how many minutes you typed, and how many times you opened Alpha-OSK. With a random ID for this install, the app version, and which operating system.

## Both custom pages showed the wrong header

A custom page sets no header, so MUI leaves whatever the last MUI page wrote. Shortcut Options and the study invite both read **"Choose Install Location / Choose the folder in which to install Alpha-OSK 1.3.0."** over unrelated content. Both now call `MUI_HEADER_TEXT`. This half predates the study page.

The in-page title is gone with it, since the header carries it now. The page ends at 124u of the 140u available.

## Tests

The existing tests could not have caught any of this, because they read source text. Added:

- a geometry sweep asserting no control ends past 140u, plus a named assertion for the link itself and an overlap check
- header assertions for both custom pages, ordered before `nsDialogs::Show`, with the inverse that a header merely repeating "Choose Install Location" still fails
- two on the copy's one load-bearing claim: that it says these are totals, and that it says nothing typed is included

`test_the_page_content_names_what_is_sent` pinned the literal opening sentence, so an intended copy edit read as a regression while saying nothing about whether the page still explains itself. Relaxed to the claim. The checkbox-unchecked guard is untouched.

Each new test was verified by restoring the bug it is for: the link back at 144u fails two of them, removing a header fails three.

## How it was checked

The wizard was compiled from `build.py`'s own generator so the copy and coordinates are byte-identical to what ships, with both Sections emptied, `customInit` removed and elevation dropped so it can only draw dialogs. It ran on a private desktop (`CreateDesktopW` + `STARTUPINFO.lpDesktop`) and was captured with `PrintWindow`, so nothing appeared on screen. Geometry came from `GetWindowRect` on the live controls, not from measuring the images.

`python check.py` green.
