### PR TITLE
chore: release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Alpha-OSK are documented in this file.
 
 ## [Unreleased]
 
+## [1.4.1] (2026-09-08)
+
 ### Changed
 - **The installer's usage-statistics page now shows you the message it would send, says what it is for, and arrives with the box ticked.** It listed the ten numbers in prose and left the box empty. Two things were missing from that. It never said what the numbers are *for*, so it read as collection for its own sake; they are the only measure of whether the predictions really save clicks outside a benchmark, which settings people can actually use, and whether a release helped or hurt. And a description of a payload is something you have to take on trust, so the page now prints the payload itself, field by field with example values, in a fixed-pitch block: the field names are the real ones and the version is the version you are installing, so it cannot quietly drift away from what the app sends.
 

--- a/src/__version__.py
+++ b/src/__version__.py
@@ -5,4 +5,4 @@ Read by ``src/updater.py`` (to compare against GitHub Releases) and
 Bumping the version is a one-line change here.
 """
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"


### PR DESCRIPTION
## Summary

Version bump and changelog for **1.4.1**, which is entirely installer work landed in #100, #102 and #103 on top of yesterday's 1.4.0.

Read as a patch rather than a minor. #102 carries a `feat:` prefix, but what it changes is the wording, the payload sample and the default state of one checkbox on a wizard page that shipped in 1.4.0 a day earlier. No new surface reaches the keyboard itself, and nothing under `src/` moved.

## What ships

**Changed**
- The installer's usage-statistics page shows the message it would send, says what the numbers are for, and arrives with the box ticked (#102).

**Fixed**
- The shortcut checkboxes no longer forget what you chose (#103).
- The "Alpha-OSK is currently running" prompt no longer hides behind other windows, and is asked at Install rather than before you have committed to anything (#100).
- Updating no longer throws away words learned since the last save: the keyboard is asked to close the way clicking the X does, and only forced if it does not go (#100).

## Build pipeline

`build/windows/build.py` and `src/updater.py` both read `src/__version__.py`, so this bump is what names the installer asset `Alpha-OSK-Setup-1.4.1.exe` and what the updater compares against. Nothing else in the signing pipeline changes.

No telemetry payload, consent model or endpoint change here. `DEFAULT_ENDPOINT` is untouched and still the production Worker URL, per the release checklist's step 2a.

## Known limitation, carried deliberately

Two of the three fixes cannot protect the upgrade that delivers them, for the same reason the settings-wipe fix in 1.4.0 could not: the installer runs the **previous** version's uninstaller and close-the-app sequence before laying the new files down. A user coming from 1.4.0 or earlier still gets the ungraceful `taskkill` one last time, and so still loses whatever the model learned since its last save. Every update after this one closes the keyboard gracefully. This is stated in the changelog entry rather than left to be discovered from a bug report.

## Changelog convention

`[Unreleased]` stays as an empty header and the dated section is inserted below it, matching what the 1.4.0 release commit (ffdc080) did.

## Test plan

- `python check.py` passes on the bumped tree (ruff, format, mypy under both `--platform linux` and `--platform win32`, full pytest run). It ran twice: once before the bump and again as the pre-push hook.
- Remaining verification is manual and belongs to the release itself, because every change in this batch lives on the NSIS wizard where no test can reach it: build and sign, then run `release/Alpha-OSK-Setup-1.4.1.exe` and check the license page gates Next, the research page keeps its own heading, unticking a shortcut box survives Back/Next, the close-the-app prompt appears over the wizard on Install and cancels without touching the running keyboard, and UIAccess reaches an elevated console.

## Accessibility

No change to keystroke timing, repeat interval, key geometry or visual feedback.
