### PR TITLE
fix(prediction): let a skipped apostrophe still find the word

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,66 @@ The last of the 2026-09-02 recommendations, landed 2026-09-03, and the one whose
 
 **The gain is modest, and that is the finding.** `scripts/bench/ksr.py --pointer BIAS_X,BIAS_Y,NOISE` simulates a pointer end to end (reported key, offset, and the presses the bias is learned from) and reports each condition three ways. A pointer whose misses are mostly random (bias 0.2, 0.15; noise 0.3; about a quarter of clicks on the wrong key), the robustness check: keys only 50.5%, plus offsets 50.8%, plus learned bias 50.9%. One whose misses are mostly systematic (0.35, 0.25; 0.15; 22% wrong), the case this feature is for: 51.1%, 51.5%, **51.8%**. The earlier per-key simulation (75% to 86.5% intended-key recovery with a learned bias) was real but did not translate, because the prefix beam plus the dictionary already recover most single-key errors from the reported key alone; what a click position adds on top is a few tenths of a point, more for a systematic pointer than a scattered one. It ships because it never regresses at 0.55, costs nothing at runtime, is privacy-gated like every other learning, and because the persisted table is the first measurement of this user's actual pointer bias, which no simulation can supply. Tests: `tests/test_pointer_model.py`, `tests/test_click_position.py` (recognizer, bridge and persistence hops, each paired with the near-miss it must leave alone) and `tests/test_qml_click_position.py`, which loads `KeyButton.qml` on its own in a `QQuickView` (one item, not a Repeater delegate, so the scene point is reliable under the offscreen plugin) and presses at a known point, and which also calls the overloaded `pressKey` / `pressKeyLiteral` slots with three arguments and with one from a QML function against a real bridge: the Python tests call the slots directly and never touch Qt's overload resolution, and a three-argument call that failed to bind from QML would degrade every press to the key centre with no warning anyone would see.
 
+## The apostrophe is optional in a typed prefix
+
+Typing `ill` offers `I'll`, `hes` offers `he's`, `im` offers `I'm`. The rule is
+one clause in `NgramPredictor._matches_partial`, the single choke point every
+prefix match goes through: a word containing an apostrophe also matches a typed
+prefix that its apostrophe-stripped form starts with, **and only when the user
+has typed no apostrophe themselves** (once they have, `don'` already matches
+`don't` exactly, and stripping on top would make the prefix mean less than what
+was typed rather than more).
+
+**It belongs in the n-gram's exact match, not in the fuzzy source, and that is
+the whole finding.** A user who types `ill` for `I'll` has not mis-clicked: the
+apostrophe costs an extra click here and a layer hop on the compact layouts, so
+it is the character they skip deliberately. This is the same thing
+`_APOSTROPHE_INSERTION_PROB` (0.50 against a generic 0.15) already encodes for
+the whole-word path, one layer over. The fuzzy source structurally cannot
+rescue it mid-word: the prefix beam reaches `i'll` only through an omitted
+click at `LOG_OMIT` (-2.5), which is past `FREQUENCY_MAY_BUY` (-1.5), so
+`_protect_exact_completions` clamps it below every completion of the live
+prefix `ill`, and `ill` has eight. `he's` was not reached at all. Cheapening
+the beam's apostrophe omission was tried and is the wrong lever: it prices a
+deliberate skip as a motor error, and it still has to buy past eight exact
+completions on frequency alone.
+
+**Typing the apostrophe must not blank the bar.** `_press_char`'s gate on
+whether to re-query was `char.isalpha()`, so the apostrophe threw the bar away
+at the moment it was right: `don` put `don't` at the top, and the `'` cleared
+it one click short of the word; `i'` discarded `I'm` / `I'll` / `I'd` / `I've`,
+which are the entire reason to type an apostrophe there. That is the same
+oversight the digit had, and which the comment at that call site already
+describes. `_continues_a_word` is the gate now: letters always, plus `'` and
+`_` when there are letters in front of them (a leading one carries no prefix,
+so asking costs a round trip and returns nothing). It is deliberately a
+separate question from the word-character rule in `_press_char` that decides
+what `_current_word` keeps: that one says what a word is made of, this one says
+whether the run so far is worth asking about.
+
+Measured on the held-out AAC corpora, counting every contraction occurrence and
+typing it the way a user of this keyboard does (no apostrophe), the word is
+offered somewhere while typing it **65.1% -> 94.5%** of the time; `i'm`, the
+most common contraction in the set at 24 occurrences, was previously
+unreachable at every prefix length. Keystroke savings are unchanged to the
+decimal (49.1% aac-dev, 50.4% aac-test): those corpora type contractions *with*
+their apostrophes, so the benchmark cannot see this at all and is a regression
+check here, not a measurement of it. The remaining misses are possessives
+(`doctor's`, `today's`) that are not in the vocabulary as words, which no
+prefix rule can reach. Across a sweep of 4,056 two- and three-letter prefixes
+only 10 change, 7 by gaining a contraction and **none by losing one**; the
+words displaced are all rank 5-6 tail items.
+
+Guarded by `tests/test_ngram_predictor.py::TestTheApostropheIsOptionalInATypedPrefix`
+(the predicate), `tests/test_hybrid_predictor.py::TestASkippedApostropheStillFindsTheWord`
+(the ranking, on the shipped word lists rather than a stub, because the claim
+is about real frequencies) and
+`tests/test_keyboard_bridge.py::TestTypingTheApostropheKeepsTheBar`. Every
+positive is paired with the near-miss it must still reject, and the pairs that
+bite are the ones a rule that matched too much would satisfy: `ill` must keep
+offering `ill` and `illinois`, a prefix with no contraction behind it must grow
+none, and a bare `'` must still ask nothing.
+
 ## Short words in next-word predictions
 
 `HybridPredictor._short_word_allowed` gates one- and two-letter words out of *next-word* predictions (the filter does not apply once the user has started typing a word, where the prefix already constrains things). It used to be a blanket `len(word) <= 2` with `"i"` as the single exception, which discarded exactly the words next-word prediction is best at: after "I want", the useful pills are "to", "it", "my", "us"; after "one", they are "of" and "or". Those are also the highest-frequency words in English, so the bar was withholding its strongest guesses and offering the fourth-best instead.

--- a/src/keyboard_bridge.py
+++ b/src/keyboard_bridge.py
@@ -1805,8 +1805,9 @@ class KeyboardBridge(QObject):
             # `_current_word` of "gm" that it reset at the "@" anyway.
             #
             # The old gate here was `if char.isalpha()`, which is why a
-            # digit used to blank the bar outright.
-            if char.isalpha() or self._in_token_context():
+            # digit used to blank the bar outright, and why the apostrophe
+            # of a contraction did too until `_continues_a_word` took over.
+            if self._continues_a_word(char) or self._in_token_context():
                 self._refresh_prediction_bar()
             else:
                 self._clear_token_pills()
@@ -3358,6 +3359,30 @@ class KeyboardBridge(QObject):
     # ------------------------------------------------------------------
     #  Structured-token predictions (numbers, phone numbers, emails)
     # ------------------------------------------------------------------
+
+    def _continues_a_word(self, char: str) -> bool:
+        """Does this keystroke leave a run the word engine can complete?
+
+        Letters always do.  The apostrophe and the underscore are word
+        characters too, the same set `_press_char` keeps in
+        `_current_word` so that "don't" and "snake_case" stay single
+        tokens, but only *inside* a word: a leading one carries no prefix
+        of its own, so asking the engine about it buys nothing and costs a
+        round trip on the keystroke path.
+
+        The apostrophe is the half that was missing.  Typing "don" offers
+        "don't" at the top of the bar, and the `'` used to blank the bar
+        outright, one click short of the word; "i'" threw away the four
+        pills ("I'm", "I'll", "I'd", "I've") that are the whole reason
+        to type an apostrophe there.  That is the same oversight the digit
+        had, one character class over, and it is deliberately a separate
+        question from the word-character rule in `_press_char`: that one
+        decides what `_current_word` keeps, this one decides whether the
+        run so far is worth asking about.
+        """
+        if char.isalpha():
+            return True
+        return char in ("'", "_") and any(c.isalpha() for c in self._current_word)
 
     def _in_token_context(self) -> bool:
         """Is the run before the cursor a structured token in progress?

--- a/src/prediction/ngram_predictor.py
+++ b/src/prediction/ngram_predictor.py
@@ -778,10 +778,33 @@ class NgramPredictor:
         return sorted_candidates[:n]
 
     def _matches_partial(self, word: str, partial: str) -> bool:
-        """Check if word matches partial input."""
+        """Check if word matches partial input.
+
+        The apostrophe in a contraction is optional in the *typed* prefix,
+        so "ill" reaches "i'll", "hes" reaches "he's" and "im" reaches
+        "i'm".  This is not a fuzzy correction and deliberately does not
+        live in the fuzzy source: a user who types "ill" for "I'll" has
+        not mis-clicked, they have skipped a character that costs an extra
+        click here (and a layer hop on the compact layouts), which is the
+        same reasoning `_APOSTROPHE_INSERTION_PROB` already encodes for the
+        whole-word path.  Matching here lets the contraction compete on its
+        own count against the other exact completions, which is the only
+        way it can win: "ill" is a live prefix of eight ordinary words, so
+        the prefix beam's apostrophe path (an omitted click at -2.5, past
+        `FREQUENCY_MAY_BUY`) is clamped below every one of them and never
+        reaches the bar at all.
+
+        Only when the user has typed no apostrophe themselves.  Once they
+        have, "don'" already matches "don't" exactly, and stripping would
+        make the prefix mean less than what was typed rather than more.
+        """
         if not partial:
             return True
-        return word.startswith(partial)
+        if word.startswith(partial):
+            return True
+        if "'" in word and "'" not in partial:
+            return word.replace("'", "").startswith(partial)
+        return False
 
     def _top_unigrams(self, n: int) -> List[str]:
         """Get top n words by frequency."""

--- a/tests/test_hybrid_predictor.py
+++ b/tests/test_hybrid_predictor.py
@@ -426,6 +426,63 @@ class TestMergeStrategies:
             assert merged.index("everywhere") < merged.index("narrow")
 
 
+class TestASkippedApostropheStillFindsTheWord:
+    """ "ill" offers "I'll" and "hes" offers "he's", on the real vocabulary.
+
+    The apostrophe is the character a user of this keyboard skips: it
+    costs an extra click, and a layer hop on the compact layouts.  The
+    fuzzy source cannot rescue it, which is why the match lives in the
+    n-gram's prefix rule instead.  "ill" is a live prefix of eight
+    ordinary words, so the prefix beam reaches "i'll" only through an
+    omitted click at -2.5, past ``FREQUENCY_MAY_BUY``, and
+    ``_protect_exact_completions`` clamps it below all eight; "he's" was
+    not reached at all.
+
+    These run against the shipped word lists rather than a seeded stub,
+    because the thing being asserted is a *ranking* among real
+    frequencies: a stub would prove the plumbing and not the outcome.
+    """
+
+    @pytest.mark.parametrize(
+        "typed,wanted",
+        [
+            ("ill", "I'll"),
+            ("im", "I'm"),
+            ("ive", "I've"),
+            ("hes", "he's"),
+            ("shes", "she's"),
+            ("dont", "don't"),
+            ("cant", "can't"),
+            ("youre", "you're"),
+            ("thats", "that's"),
+            ("whats", "what's"),
+        ],
+    )
+    def test_the_contraction_is_offered(self, predictor, typed, wanted) -> None:
+        words = predictor.predict(typed, n=6)
+        assert wanted in words, f"{typed!r} did not offer {wanted!r}: {words}"
+
+    @pytest.mark.parametrize(
+        "typed,wanted",
+        [("ill", "ill"), ("ill", "illinois"), ("hes", "hesitate"), ("im", "image")],
+    )
+    def test_the_ordinary_words_keep_their_place(self, predictor, typed, wanted) -> None:
+        """The inverse: the contraction joins the bar, it does not take it.
+
+        Without this, "match the word with its apostrophes removed" could
+        degrade into matching far too much and still satisfy every
+        assertion above.
+        """
+        words = predictor.predict(typed, n=6)
+        assert wanted in words, f"{typed!r} lost {wanted!r}: {words}"
+
+    @pytest.mark.parametrize("typed", ["the", "hel", "wor", "illus", "hesi", "imp"])
+    def test_a_prefix_with_no_contraction_behind_it_is_unchanged(self, predictor, typed) -> None:
+        """Nothing apostrophe-shaped may appear where none was asked for."""
+        words = predictor.predict(typed, n=6)
+        assert not [w for w in words if "'" in w], f"{typed!r} grew a contraction: {words}"
+
+
 class TestShortWordsAreOfferedAsNextWords:
     """Two-letter words are the ones next-word prediction is best at.
 

--- a/tests/test_keyboard_bridge.py
+++ b/tests/test_keyboard_bridge.py
@@ -2817,6 +2817,61 @@ def _press(bridge: KeyboardBridge, text: str) -> None:
             bridge.pressKey(ch)
 
 
+class TestTypingTheApostropheKeepsTheBar:
+    """The apostrophe of a contraction must not blank the suggestion bar.
+
+    The gate deciding whether to re-query was ``char.isalpha()``, which
+    is the same oversight the digit had and which the comment at that
+    call site already describes.  The cost here is sharper than for a
+    digit, because the bar is blanked at the moment it was *right*:
+    typing "don" puts "don't" at the top of the bar, and the apostrophe
+    threw it away one click short of the word.  "i'" is the worst case,
+    since "I'm" / "I'll" / "I'd" / "I've" are the entire reason to type
+    an apostrophe in that position.
+
+    Each case is paired with the near-miss it must leave alone, because
+    a gate that simply re-queries on everything would satisfy the
+    positives on its own.
+    """
+
+    @staticmethod
+    def _bar(bridge: KeyboardBridge, text: str) -> list:
+        bridge.resetContext()
+        _press(bridge, text)
+        return list(bridge._predictions)
+
+    def test_the_bar_survives_the_apostrophe(self, bridge: KeyboardBridge):
+        assert self._bar(bridge, "don'")
+        assert self._bar(bridge, "i'")
+        assert self._bar(bridge, "he'")
+
+    def test_the_contraction_is_what_is_offered(self, bridge: KeyboardBridge):
+        """Not merely non-empty: the bar has to hold the word being typed."""
+        assert "don't" in self._bar(bridge, "don'")
+        assert "he's" in self._bar(bridge, "he'")
+        assert "I'll" in self._bar(bridge, "i'")
+
+    def test_a_leading_apostrophe_still_asks_nothing(self, bridge: KeyboardBridge):
+        """The inverse.  A bare "'" has no prefix to complete.
+
+        It is a word character, so it stays in ``_current_word``, but
+        there is nothing in front of it for the engine to work from and
+        querying would only cost a round trip on the keystroke path.
+        """
+        assert self._bar(bridge, "'") == []
+
+    def test_the_word_character_rule_is_unchanged(self, bridge: KeyboardBridge):
+        """The apostrophe stays in the word, as it always did."""
+        bridge.resetContext()
+        _press(bridge, "don'")
+        assert bridge._current_word == "don'"
+
+    def test_ordinary_punctuation_still_clears_the_bar(self, bridge: KeyboardBridge):
+        """The inverse: only word characters were let through, not all of them."""
+        for text in ("hello-", "hello/", "hello*"):
+            assert self._bar(bridge, text) == [], text
+
+
 class TestAutoCapitalizeIsNotAHeldShift:
     """Auto-capitalize must capitalize the next letter and nothing else.
 

--- a/tests/test_ngram_predictor.py
+++ b/tests/test_ngram_predictor.py
@@ -938,6 +938,84 @@ class TestReinforceContext:
         assert p.bigrams["hello"]["world"] == 1
 
 
+class TestTheApostropheIsOptionalInATypedPrefix:
+    """ "ill" has to reach "i'll", and "hes" has to reach "he's".
+
+    Typing the apostrophe costs an extra click here, and a layer hop on
+    the compact layouts, so it is the character a user skips.  That is
+    not a mis-click and the fuzzy source cannot rescue it: "ill" is a
+    live prefix of eight ordinary words, so the prefix beam's apostrophe
+    path (an omitted click at -2.5, past ``FREQUENCY_MAY_BUY``) is
+    clamped below every one of them.  Matching it here instead lets the
+    contraction compete on its own count.
+
+    Every positive case below is paired with the near-miss it must still
+    reject, because a rule that only ever says yes would make the prefix
+    mean nothing at all.
+    """
+
+    def test_a_skipped_apostrophe_still_matches(self):
+        p = NgramPredictor()
+        assert p._matches_partial("i'll", "ill")
+        assert p._matches_partial("he's", "hes")
+        assert p._matches_partial("i'm", "im")
+        assert p._matches_partial("don't", "dont")
+
+    def test_the_rest_of_the_prefix_still_has_to_match(self):
+        """The inverse: dropping the apostrophe is not dropping the rule."""
+        p = NgramPredictor()
+        assert not p._matches_partial("i'll", "ilx")
+        assert not p._matches_partial("he's", "his")
+        assert not p._matches_partial("don't", "dent")
+        assert not p._matches_partial("i'm", "am")
+
+    def test_a_word_with_no_apostrophe_is_untouched(self):
+        p = NgramPredictor()
+        assert p._matches_partial("illinois", "ill")
+        assert not p._matches_partial("illinois", "iln")
+        assert not p._matches_partial("hesitate", "hs")
+
+    def test_a_typed_apostrophe_is_matched_literally(self):
+        """Once the user types it, the prefix means more, not less.
+
+        "don'" already reaches "don't" by the ordinary rule, and
+        stripping on top of that would let a typed apostrophe match a
+        position the word does not have one in.
+        """
+        p = NgramPredictor()
+        assert p._matches_partial("don't", "don'")
+        assert p._matches_partial("i'll", "i'l")
+        assert not p._matches_partial("illinois", "i'l")
+        assert not p._matches_partial("i'll", "il'l")
+
+    def test_the_contraction_reaches_the_candidates(self):
+        """End to end through the scorer, not just the predicate.
+
+        Seeded rather than assumed: a bare ``NgramPredictor`` carries no
+        apostrophe words at all (they arrive with ``base_dictionary.txt``,
+        which only the hybrid loads), so an unseeded version of this test
+        would pass against a predicate that had stopped working.  The
+        shipped-vocabulary case is
+        ``test_hybrid_predictor.py::TestASkippedApostropheStillFindsTheWord``.
+        """
+        p = NgramPredictor()
+        for word in ("i'll", "he's", "i'm"):
+            p.unigrams[word] = 9000
+            p._base_unigrams[word] = 9000
+        for prefix, wanted in (("ill", "i'll"), ("hes", "he's"), ("im", "i'm")):
+            words = [w for w, _ in p.predict_with_scores(prefix, 8)]
+            assert wanted in words, f"{prefix!r} did not offer {wanted!r}: {words}"
+
+    def test_the_ordinary_completions_are_not_displaced(self):
+        """The inverse: the contraction joins the bar, it does not take it."""
+        p = NgramPredictor()
+        p.unigrams["i'll"] = 9000
+        p._base_unigrams["i'll"] = 9000
+        words = [w for w, _ in p.predict_with_scores("ill", 8)]
+        assert "ill" in words
+        assert "illinois" in words
+
+
 class TestTaughtAcronymsAreLearnable:
     """A deliberately-capitalised acronym is exempt from the shape filter.
 


### PR DESCRIPTION
Typing `ill` offered `illinois`, `illegal` and `ill` but never `I'll`. `hes` never offered `he's`, `im` never offered `I'm`, `shes` never offered `she's`.

## Why it happened

The apostrophe costs an extra click on this keyboard, and a layer hop on the compact layouts, so it is the character a user skips deliberately. That is not a mis-click, and the fuzzy source structurally could not rescue it:

- The prefix beam reaches `i'll` from `ill` only through an omitted click at `LOG_OMIT` (-2.5), which is past `FREQUENCY_MAY_BUY` (-1.5), so `_protect_exact_completions` clamps it below every completion of the live prefix `ill`. There are eight.
- `he's` was not reached at all.
- `im` is two characters, so the beam's `MIN_TYPED` guard refuses it outright.

The contractions that did work (`dont`, `cant`, `its`, `whats`) worked only because their exact-completion families happen to be small enough that the demoted candidate still surfaced at rank 4 or 5.

## The fix

One clause in `NgramPredictor._matches_partial`, the single choke point every prefix match goes through: a word containing an apostrophe also matches a typed prefix its apostrophe-stripped form starts with, **and only while the user has typed no apostrophe themselves** (once they have, `don'` already matches `don't` exactly, and stripping on top would make the prefix mean less than what was typed rather than more).

Putting it in the exact source rather than the fuzzy one is the point: the contraction then competes on its own count instead of having to buy its way past eight exact completions. It is the same reasoning `_APOSTROPHE_INSERTION_PROB` (0.50 against a generic 0.15) already encodes for the whole-word path, one layer over. Cheapening the beam's apostrophe omission was considered and rejected: it prices a deliberate skip as a motor error and still leaves the clamp to fight.

### Second half: typing the apostrophe blanked the bar

`_press_char`'s gate on whether to re-query was `char.isalpha()`, so the apostrophe threw the bar away at the moment it was right. Typing `don` put `don't` at the top of the bar and the `'` cleared it, one click short of the word. `i'` discarded `I'm` / `I'll` / `I'd` / `I've`, which are the entire reason to type an apostrophe in that position.

That is the same oversight the digit had, and which the comment at that call site already describes. `_continues_a_word` is the gate now: letters always, plus `'` and `_` when there are letters in front of them. A leading `'` still asks nothing, since it carries no prefix and the round trip would return nothing.

## Measurements

**The gain.** On the held-out AAC corpora, taking every contraction occurrence and typing it the way a user of this keyboard does (no apostrophe), the intended word is offered somewhere while typing it:

| | offered |
|---|---|
| before | 71/109 = **65.1%** |
| after | 103/109 = **94.5%** |

`i'm` is the most common contraction in the set (24 occurrences) and was previously unreachable at every prefix length. The 6 remaining misses are possessives (`doctor's`, `today's`, `tracy's`) that are not in the vocabulary as words, which no prefix rule can reach.

**Keystroke savings: unchanged to the decimal** (49.1% aac-dev, 50.4% aac-test, matching the documented baselines). Those corpora type contractions *with* their apostrophes, so the benchmark cannot see this change at all. It is a regression check here, not a measurement of the fix, and the PR is explicit about that rather than quoting a flat number as if it were evidence either way.

**Blast radius.** Sweeping all 4,056 two- and three-letter prefixes, before against after:

- 10 prefixes change (0.2%)
- 7 change by **gaining** a contraction
- **0** change by losing one
- the 9 words displaced anywhere are all rank 5-6 tail items (`impact`, `illustration`, `ideal`, `website`, `yup`, ...), each displaced by a contraction far more common in conversational text

Three prefixes (`fav`, `hen`, `yu`) shuffle at ranks 5-6 without any apostrophe word entering the bar; that is the merge's sum-to-1 normalisation denominator shifting when one more candidate enters the n-gram source, breaking near-ties differently.

## Tests

Every positive is paired with the near-miss it must still reject, and each new test was verified to **fail without the fix**.

- `test_ngram_predictor.py::TestTheApostropheIsOptionalInATypedPrefix` — the predicate. The end-to-end case seeds the contractions explicitly and says why: a bare `NgramPredictor` carries no apostrophe words at all (they arrive with `base_dictionary.txt`, which only the hybrid loads), so an unseeded version would pass against a predicate that had stopped working.
- `test_hybrid_predictor.py::TestASkippedApostropheStillFindsTheWord` — the ranking, on the shipped word lists rather than a stub, because the claim is about real frequencies. Includes the inverse that `ill` keeps offering `ill` and `illinois`, and that a prefix with no contraction behind it grows none.
- `test_keyboard_bridge.py::TestTypingTheApostropheKeepsTheBar` — the gate, with the inverses that a bare `'` still asks nothing and that ordinary punctuation still clears the bar.

Full gate green: `ruff check`, `ruff format --check`, `mypy` under both `--platform linux` and `--platform win32`, and 2546 passed / 4 skipped.

## Flagging per CLAUDE.md

This changes the prediction engine. Two judgement calls worth a look:

1. **`id` now offers `I'd` at rank 1**, ahead of `idea` (which moves to rank 2). Same for `iv` → `I've` ahead of `ivory`, and `wer` → `we're` ahead of `were`. For conversational AAC text I think that is right, but it is a rank-1 takeover on short prefixes and is the one thing here that is a preference rather than a bug fix.
2. Branched from `origin/main`, so this does not include PR #108's short-word work. The two are adjacent (#108 touches `allow_short_prefix` in the same merge) but independent; no conflict expected.